### PR TITLE
Redesign podcast listing page and episode detail template

### DIFF
--- a/src/pages/podcasts.tsx
+++ b/src/pages/podcasts.tsx
@@ -1,27 +1,97 @@
-import { graphql, useStaticQuery } from 'gatsby';
-import React from 'react';
+import { Link, graphql, useStaticQuery } from 'gatsby';
+import React, { useMemo } from 'react';
 
-import EpisodeItem from '../components/episodeItem';
 import Layout from '../components/layout';
-import LayoutSidebar from '../components/layoutSidebar';
 import SEO from '../components/seo';
+import Text from '../components/text';
+import { useAudioPlayer } from '../components/player/AudioProvider';
+import { PlayButton } from '../components/player/PlayButton';
+
+function EpisodeCard({ episode }: { episode: any }) {
+  const audioPlayerData = useMemo(
+    () => ({
+      title: episode.title,
+      audio: { src: episode.enclosure.url, type: 'audio/mpeg' },
+      link: `/podcasts/${episode.guid}`,
+    }),
+    [episode],
+  );
+  const player = useAudioPlayer(audioPlayerData);
+
+  // Supprimer les balises HTML du résumé
+  const plainSummary = episode.itunes.summary
+    ? episode.itunes.summary.replace(/<[^>]*>/g, '').substring(0, 140) + '…'
+    : '';
+
+  return (
+    <article className="group flex flex-col">
+      {/* Pochette */}
+      <Link
+        to={`/podcasts/${episode.guid}`}
+        className="block overflow-hidden rounded-sm"
+      >
+        <div className="aspect-square overflow-hidden bg-stone-100">
+          <img
+            src={episode.itunes.image}
+            alt={episode.title}
+            className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+          />
+        </div>
+      </Link>
+
+      {/* Contenu */}
+      <div className="mt-4 flex flex-1 flex-col">
+        <p className="text-xs font-semibold uppercase tracking-widest text-clay-500">
+          Saison {episode.itunes.season} · Épisode {episode.itunes.episode}
+          {episode.itunes.duration && ` · ${episode.itunes.duration}`}
+        </p>
+
+        <Link to={`/podcasts/${episode.guid}`}>
+          <h2 className="mt-2 font-display text-xl font-semibold leading-snug text-stone-900 transition-colors hover:text-clay-500">
+            {episode.title}
+          </h2>
+        </Link>
+
+        <p className="mt-2 flex-1 text-sm leading-relaxed text-stone-500">
+          {plainSummary}
+        </p>
+
+        <div className="mt-4 flex items-center gap-3">
+          <PlayButton player={player} size="small" />
+          <span className="text-xs font-semibold uppercase tracking-widest text-clay-500">
+            Écouter
+          </span>
+        </div>
+      </div>
+    </article>
+  );
+}
 
 const PodcastsPage = ({ data }) => {
   const allEpisodes = data.allAnchorEpisode.nodes;
 
   return (
     <Layout>
-      <LayoutSidebar>
-        {allEpisodes.map((episode) => {
-          return (
-            <EpisodeItem
-              key={episode.id}
-              episode={episode}
-              isSummaryTruncate={true}
-            />
-          );
-        })}
-      </LayoutSidebar>
+      {/* En-tête */}
+      <section className="m-auto mb-10 mt-8 w-3/4">
+        <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-clay-500">
+          Tous les épisodes
+        </p>
+        <Text
+          as="h1"
+          variant="h1"
+          className="text-4xl leading-tight md:text-5xl"
+        >
+          Podcasts sur les femmes artistes
+        </Text>
+      </section>
+
+      {/* Grille d'épisodes */}
+      <div className="m-auto mb-20 grid w-3/4 grid-cols-1 gap-10 sm:grid-cols-2 lg:grid-cols-3">
+        {allEpisodes.map((episode) => (
+          <EpisodeCard key={episode.id} episode={episode} />
+        ))}
+      </div>
     </Layout>
   );
 };
@@ -29,8 +99,8 @@ const PodcastsPage = ({ data }) => {
 export const Head = () => {
   return (
     <SEO
-      title="Écoutez des discussions inspirantes sur les femmes artistes et leur travail avec notre podcast."
-      description="Explorez l'art au féminin d'une manière tout à fait unique grâce à notre collection de podcasts stimulants. Notre série de podcasts vous offre un accès privilégié à des récits captivants sur la créativité, l'histoire de l'art et l'influence des femmes artistes. Écoutez, apprenez et laissez-vous inspirer par les voix éclairées de l'art au féminin."
+      title="Tous les épisodes — ART au féminin, le podcast sur les femmes artistes"
+      description="Écoutez tous les épisodes du podcast ART au féminin, présenté par Aldjia Boughias. Des récits captivants sur les femmes artistes qui ont marqué l'histoire de l'art."
     />
   );
 };
@@ -40,8 +110,20 @@ export default function PodcastQuery() {
     query {
       allAnchorEpisode(sort: { isoDate: DESC }) {
         nodes {
+          id
           isoDate
-          ...AnchorEpisodeFragment
+          guid
+          title
+          itunes {
+            summary
+            image
+            episode
+            season
+            duration
+          }
+          enclosure {
+            url
+          }
         }
       }
     }

--- a/src/templates/episode.tsx
+++ b/src/templates/episode.tsx
@@ -1,26 +1,25 @@
-import React from 'react';
-import { useMemo } from 'react';
+import React, { useMemo } from 'react';
 
 import Layout from '../components/layout';
-import LayoutSidebar from '../components/layoutSidebar';
 import { useAudioPlayer } from '../components/player/AudioProvider';
 import { PlayButton } from '../components/player/PlayButton';
 import SEO from '../components/seo';
-import Text from '../components/text';
 import { dutationToString } from '../utils/dutationToString';
+import { allPodcastPlatforms } from '../pages/links';
 
 export default function Episode({ pageContext }) {
   const title = pageContext.title;
   const duration = dutationToString(pageContext.itunes.duration);
+  const season = pageContext.itunes.season;
+  const episode = pageContext.itunes.episode;
+  const image = pageContext.itunes.image;
+  const summary = pageContext.itunes.summary;
 
   const audioPlayerData = useMemo(
     () => ({
-      title: pageContext.title,
-      audio: {
-        src: pageContext.enclosure.url,
-        type: 'audio/mpeg',
-      },
-      link: `/${pageContext.guid}`,
+      title,
+      audio: { src: pageContext.enclosure.url, type: 'audio/mpeg' },
+      link: `/podcasts/${pageContext.guid}`,
     }),
     [pageContext]
   );
@@ -28,59 +27,139 @@ export default function Episode({ pageContext }) {
 
   return (
     <Layout withLastPodcast={false}>
-      <LayoutSidebar>
-        <article className="prose prose-blue text-gray-500">
-          <h1 className="text-gray-700">{title}</h1>
 
-          <p className="text-gray-500">
-            <em>Saison {pageContext.itunes.season}</em>
-            <span className="mx-4">•</span>
-            <em>Épisode {pageContext.itunes.episode}</em>
-            <span className="mx-4">•</span>
-            <em>{duration}</em>
-          </p>
+      {/* ── HERO IMAGE ───────────────────────────────────────────── */}
+      <div className="-mx-4 -mt-12 relative h-[55vh] min-h-[340px] overflow-hidden">
+        <img
+          src={image}
+          alt={title}
+          className="h-full w-full object-cover object-center"
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-black/85 via-black/40 to-transparent" />
 
-          <div className="flex items-center gap-4">
-            <PlayButton player={player} size="small" />
-            <Text className="font-merri text-slate-500">Écouter</Text>
+        <div className="absolute bottom-0 left-0 right-0 px-6 pb-10 lg:px-0">
+          <div className="mx-auto max-w-3xl">
+            <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-clay-300">
+              Saison {season} · Épisode {episode}
+              {duration && <span> · {duration}</span>}
+            </p>
+            <h1 className="font-display text-3xl font-semibold leading-tight text-white md:text-4xl lg:text-5xl">
+              {title}
+            </h1>
           </div>
+        </div>
+      </div>
 
-          <div
-            className="my-12"
-            dangerouslySetInnerHTML={{ __html: pageContext.itunes.summary }}
-          />
+      {/* ── CONTENU ──────────────────────────────────────────────── */}
+      <div className="mx-auto max-w-3xl px-6 lg:px-0">
 
-          <hr className="separator" />
-        </article>
-      </LayoutSidebar>
+        {/* Bouton play */}
+        <div className="flex items-center gap-5 border-b border-clay-200 py-8">
+          <PlayButton player={player} size="medium" />
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-widest text-clay-500">
+              Écouter l'épisode
+            </p>
+            {duration && (
+              <p className="mt-0.5 text-sm text-stone-400">{duration}</p>
+            )}
+          </div>
+        </div>
+
+        {/* Résumé */}
+        <div
+          className="prose prose-stone my-10 max-w-none text-stone-600 prose-p:leading-relaxed prose-p:text-stone-600 prose-a:text-clay-500 prose-a:no-underline hover:prose-a:underline"
+          dangerouslySetInnerHTML={{ __html: summary }}
+        />
+
+        <hr className="separator" />
+      </div>
+
+      {/* ── PANNEAUX BAS ─────────────────────────────────────────── */}
+      <div className="mx-auto mb-20 grid max-w-5xl grid-cols-1 gap-6 px-6 lg:grid-cols-3 lg:px-0">
+
+        {/* Plateformes d'écoute */}
+        <div className="rounded-sm border border-clay-200 bg-cream-50 p-6">
+          <p className="mb-1 text-xs font-bold uppercase tracking-widest text-clay-500">
+            Écouter sur
+          </p>
+          <h2 className="mb-5 font-display text-xl font-semibold text-stone-900">
+            Toutes les plateformes
+          </h2>
+          <ul className="space-y-3">
+            {allPodcastPlatforms
+              .filter((p) => p.name !== 'Anchor')
+              .map((platform) => (
+                <li key={platform.name}>
+                  <a
+                    href={platform.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-3 text-sm font-medium text-stone-700 transition-colors hover:text-clay-500"
+                  >
+                    <img
+                      src={platform.imageUrl}
+                      alt={platform.name}
+                      className="size-6 shrink-0"
+                    />
+                    {platform.name}
+                  </a>
+                </li>
+              ))}
+          </ul>
+        </div>
+
+        {/* Instagram */}
+        <div className="rounded-sm border border-clay-200 bg-cream-50 p-6">
+          <p className="mb-1 text-xs font-bold uppercase tracking-widest text-clay-500">
+            Communauté
+          </p>
+          <h2 className="mb-3 font-display text-xl font-semibold text-stone-900">
+            Suivez ART <span className="italic font-light">au féminin</span>
+          </h2>
+          <p className="mb-5 text-sm leading-relaxed text-stone-500">
+            Pour encore plus de contenus sur les femmes artistes, suivez le compte Instagram du podcast.
+          </p>
+          <a
+            href="https://www.instagram.com/artaufeminin/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-full border border-clay-500 px-4 py-2 text-xs font-bold uppercase tracking-widest text-clay-500 transition-colors hover:bg-clay-500 hover:text-white"
+          >
+            @artaufeminin
+          </a>
+        </div>
+
+        {/* Mécénat */}
+        <div className="rounded-sm border border-clay-200 bg-cream-50 p-6">
+          <p className="mb-1 text-xs font-bold uppercase tracking-widest text-clay-500">
+            Mécénat
+          </p>
+          <h2 className="mb-3 font-display text-xl font-semibold text-stone-900">
+            Soutenez le podcast
+          </h2>
+          <p className="mb-5 text-sm leading-relaxed text-stone-500">
+            Si vous appréciez ce travail, vous pouvez soutenir ART au féminin sur Tipeee. Chaque contribution compte.
+          </p>
+          <a
+            href="https://fr.tipeee.com/art-au-feminin"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-full border border-clay-500 px-4 py-2 text-xs font-bold uppercase tracking-widest text-clay-500 transition-colors hover:bg-clay-500 hover:text-white"
+          >
+            Soutenir sur Tipeee
+          </a>
+        </div>
+
+      </div>
     </Layout>
   );
 }
 
-export async function getStaticProps({ pageContext }) {
-  const episode = {
-    id: pageContext.guid.toString,
-    title: pageContext.title,
-    description: pageContext.description,
-    audio: pageContext.enclosure.url,
-  };
-
-  if (!episode) {
-    return {
-      notFound: true,
-    };
-  }
-
-  return {
-    props: {
-      episode,
-    },
-    revalidate: 10,
-  };
-}
-
 export const Head = ({ pageContext }) => {
   const title = pageContext.title;
-  const description = pageContext.contentSnippet.substring(0, 155);
-  return <SEO title={`Podcast ${title}`} description={description} />;
+  const description = pageContext.contentSnippet
+    ? pageContext.contentSnippet.substring(0, 155)
+    : title;
+  return <SEO title={`${title} — ART au féminin`} description={description} />;
 };


### PR DESCRIPTION
## Summary

- **`podcasts.tsx`**: New 3-column card grid — square cover images with hover zoom, clay-colored season/episode/duration metadata, Cormorant Garamond titles, plain-text truncated summaries (HTML stripped), inline PlayButton
- **`episode.tsx`**: Full-bleed hero image (`h-[55vh]`) with gradient overlay and title/meta at bottom; centered `max-w-3xl` content column with PlayButton + prose summary; three elegant bordered panels at bottom (podcast platforms, Instagram CTA, Tipeee support)

## Test plan

- [ ] Visit `/podcasts` — verify 3-column grid with card hover effects
- [ ] Click an episode — verify hero image fills viewport with title overlay
- [ ] Verify PlayButton works from both the listing and detail pages
- [ ] Check bottom 3 panels (platforms list, Instagram link, Tipeee link)
- [ ] Check mobile layout (single column)

🤖 Generated with [Claude Code](https://claude.com/claude-code)