### PR TITLE
Extract shared ContentCard — unify podcast and article cards

### DIFF
--- a/src/components/article-list.tsx
+++ b/src/components/article-list.tsx
@@ -3,6 +3,7 @@ import { RichText, RichTextBlock } from 'prismic-reactjs';
 import React from 'react';
 
 import { formatHumanDate, splitDate } from '../utils/date';
+import { ContentCard } from './content-card';
 
 interface ArticleProps {
   uid: string;
@@ -26,70 +27,16 @@ interface ArticleListItemProps {
   isRow?: boolean;
 }
 
-function ArticleCard({ article }: { article: ArticleProps }) {
-  const slug = article.uid;
-  const thumbnailUrl = article.data.image.url;
+function getDate(article: ArticleProps): string {
   const articleDate = formatHumanDate(article.data.date);
   const publishDate = formatHumanDate(splitDate(article.first_publication_date));
-  const date =
-    articleDate !== 'jeudi 1 janvier 1970' ? articleDate : publishDate;
-
-  const title = RichText.asText(article.data.title.richText);
-  const description = RichText.asText(article.data.description.richText);
-  const descriptionTruncated =
-    description.length > 140 ? description.substring(0, 140) + '…' : description;
-
-  return (
-    <article className="group flex flex-col">
-      {/* Image */}
-      <Link
-        to={`/articles/${slug}`}
-        className="block overflow-hidden rounded-sm"
-      >
-        <div className="aspect-[4/3] overflow-hidden bg-stone-100">
-          <img
-            src={thumbnailUrl}
-            alt={title}
-            className="h-full w-full object-cover object-center transition-transform duration-500 group-hover:scale-105"
-          />
-        </div>
-      </Link>
-
-      {/* Contenu */}
-      <div className="mt-4 flex flex-1 flex-col">
-        <p className="text-xs font-semibold uppercase tracking-widest text-clay-500">
-          {date}
-        </p>
-
-        <Link to={`/articles/${slug}`}>
-          <h2 className="mt-2 font-display text-xl font-semibold leading-snug text-stone-900 transition-colors hover:text-clay-500">
-            {title}
-          </h2>
-        </Link>
-
-        <p className="mt-2 flex-1 text-sm leading-relaxed text-stone-500">
-          {descriptionTruncated}
-        </p>
-
-        <Link
-          to={`/articles/${slug}`}
-          className="mt-4 text-xs font-semibold uppercase tracking-widest text-clay-500 transition-colors hover:text-clay-700"
-        >
-          Lire l'article →
-        </Link>
-      </div>
-    </article>
-  );
+  return articleDate !== 'jeudi 1 janvier 1970' ? articleDate : publishDate;
 }
 
 function ArticleRow({ article }: { article: ArticleProps }) {
   const slug = article.uid;
   const thumbnailUrl = article.data.image.url;
-  const articleDate = formatHumanDate(article.data.date);
-  const publishDate = formatHumanDate(splitDate(article.first_publication_date));
-  const date =
-    articleDate !== 'jeudi 1 janvier 1970' ? articleDate : publishDate;
-
+  const date = getDate(article);
   const title = RichText.asText(article.data.title.richText);
   const description = RichText.asText(article.data.description.richText);
   const descriptionTruncated =
@@ -102,7 +49,7 @@ function ArticleRow({ article }: { article: ArticleProps }) {
         className="flex flex-col gap-5 sm:flex-row sm:items-start"
       >
         <div className="w-full shrink-0 overflow-hidden rounded-sm sm:w-40">
-          <div className="aspect-[4/3] overflow-hidden bg-stone-100 sm:aspect-square">
+          <div className="aspect-square overflow-hidden bg-stone-100">
             <img
               src={thumbnailUrl}
               alt={title}
@@ -139,9 +86,32 @@ export function ArticleList({ allArticles, isRow }: ArticleListItemProps) {
 
   return (
     <div className="m-auto mb-20 grid w-3/4 grid-cols-1 gap-10 sm:grid-cols-2 lg:grid-cols-3">
-      {allArticles.map((article) => (
-        <ArticleCard article={article} key={article.uid} />
-      ))}
+      {allArticles.map((article) => {
+        const title = RichText.asText(article.data.title.richText);
+        const description = RichText.asText(article.data.description.richText);
+        const descriptionTruncated =
+          description.length > 140 ? description.substring(0, 140) + '…' : description;
+
+        return (
+          <ContentCard
+            key={article.uid}
+            href={`/articles/${article.uid}`}
+            imageUrl={article.data.image.url}
+            imageAlt={title}
+            meta={getDate(article)}
+            title={title}
+            description={descriptionTruncated}
+            action={
+              <Link
+                to={`/articles/${article.uid}`}
+                className="text-xs font-semibold uppercase tracking-widest text-clay-500 transition-colors hover:text-clay-700"
+              >
+                Lire l'article →
+              </Link>
+            }
+          />
+        );
+      })}
     </div>
   );
 }

--- a/src/components/content-card.tsx
+++ b/src/components/content-card.tsx
@@ -1,0 +1,58 @@
+import { Link } from 'gatsby';
+import React from 'react';
+
+interface ContentCardProps {
+  href: string;
+  imageUrl: string;
+  imageAlt: string;
+  meta: string;
+  title: string;
+  description: string;
+  action: React.ReactNode;
+}
+
+export function ContentCard({
+  href,
+  imageUrl,
+  imageAlt,
+  meta,
+  title,
+  description,
+  action,
+}: ContentCardProps) {
+  return (
+    <article className="group flex flex-col">
+      {/* Image */}
+      <Link to={href} className="block overflow-hidden rounded-sm">
+        <div className="aspect-square overflow-hidden bg-stone-100">
+          <img
+            src={imageUrl}
+            alt={imageAlt}
+            className="h-full w-full object-cover object-center transition-transform duration-500 group-hover:scale-105"
+          />
+        </div>
+      </Link>
+
+      {/* Contenu */}
+      <div className="mt-4 flex flex-1 flex-col">
+        <p className="text-xs font-semibold uppercase tracking-widest text-clay-500">
+          {meta}
+        </p>
+
+        <Link to={href}>
+          <h2 className="mt-2 font-display text-xl font-semibold leading-snug text-stone-900 transition-colors hover:text-clay-500">
+            {title}
+          </h2>
+        </Link>
+
+        <p className="mt-2 flex-1 text-sm leading-relaxed text-stone-500">
+          {description}
+        </p>
+
+        <div className="mt-4">
+          {action}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/pages/design-system.tsx
+++ b/src/pages/design-system.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 
 import Button from '../components/button';
+import { ContentCard } from '../components/content-card';
 import Layout from '../components/layout';
 import SEO from '../components/seo';
 
@@ -259,37 +260,57 @@ export default function DesignSystemPage(): ReactElement {
       <Section title="Cards">
         <div className="space-y-10">
 
-          {/* Card épisode / article — grille */}
+          {/* ContentCard — composant partagé podcast + article */}
           <div>
-            <p className="mb-6 text-sm font-semibold text-stone-600">
-              Card épisode / article — grille 3 colonnes
+            <p className="mb-2 text-sm font-semibold text-stone-600">
+              <code className="rounded bg-cream-200 px-1 py-0.5 text-xs font-mono">ContentCard</code> — composant partagé, utilisé sur <code className="rounded bg-cream-200 px-1 py-0.5 text-xs font-mono">/podcasts</code> et <code className="rounded bg-cream-200 px-1 py-0.5 text-xs font-mono">/articles</code>
+            </p>
+            <p className="mb-6 text-xs text-stone-400">
+              Seul le slot <code className="font-mono">action</code> varie : PlayButton pour les épisodes, lien texte pour les articles.
             </p>
             <div className="grid grid-cols-1 gap-10 sm:grid-cols-2 lg:grid-cols-3">
-              {[1, 2, 3].map((i) => (
-                <article key={i} className="group flex flex-col">
-                  <div className="block overflow-hidden rounded-sm">
-                    <div className="aspect-square overflow-hidden bg-stone-100">
-                      <div className="h-full w-full bg-gradient-to-br from-cream-200 to-clay-200 transition-transform duration-500 group-hover:scale-105" />
-                    </div>
-                  </div>
-                  <div className="mt-4 flex flex-1 flex-col">
-                    <p className="text-xs font-semibold uppercase tracking-widest text-clay-500">
-                      Saison 3 · Épisode {i}
-                    </p>
-                    <h3 className="mt-2 font-display text-xl font-semibold leading-snug text-stone-900 transition-colors hover:text-clay-500">
-                      Titre de l'épisode ou de l'article
-                    </h3>
-                    <p className="mt-2 flex-1 text-sm leading-relaxed text-stone-500">
-                      Courte description tronquée à 140 caractères pour donner envie de lire ou d'écouter…
-                    </p>
-                    <div className="mt-4">
-                      <span className="text-xs font-semibold uppercase tracking-widest text-clay-500">
-                        Lire l'article →
-                      </span>
-                    </div>
-                  </div>
-                </article>
-              ))}
+              {/* Variante épisode */}
+              <ContentCard
+                href="#"
+                imageUrl="https://images.unsplash.com/photo-1579783902614-a3fb3927b6a5?w=400&h=400&fit=crop"
+                imageAlt="Exemple épisode"
+                meta="Saison 3 · Épisode 12 · 42 min"
+                title="Georgia O'Keeffe, peintre de l'espace américain"
+                description="Des grandes fleurs aux paysages du Nouveau-Mexique, découvrez l'univers singulier de cette artiste majeure…"
+                action={
+                  <span className="text-xs font-semibold uppercase tracking-widest text-clay-500">
+                    ▶ Écouter
+                  </span>
+                }
+              />
+              {/* Variante article */}
+              <ContentCard
+                href="#"
+                imageUrl="https://images.unsplash.com/photo-1579783902614-a3fb3927b6a5?w=400&h=400&fit=crop"
+                imageAlt="Exemple article"
+                meta="lundi 14 avril 2025"
+                title="Camille Claudel, sculpteure dans l'ombre de Rodin"
+                description="Son œuvre reste méconnue malgré son génie. Retour sur le parcours d'une artiste brisée par son époque…"
+                action={
+                  <span className="text-xs font-semibold uppercase tracking-widest text-clay-500">
+                    Lire l'article →
+                  </span>
+                }
+              />
+              {/* Variante sans image */}
+              <ContentCard
+                href="#"
+                imageUrl="https://images.unsplash.com/photo-1579783902614-a3fb3927b6a5?w=400&h=400&fit=crop"
+                imageAlt="Exemple"
+                meta="Saison 2 · Épisode 5"
+                title="Frida Kahlo, l'art comme autobiographie"
+                description="Entre douleur et couleur, Frida Kahlo a transformé sa vie en œuvre. Un épisode incontournable…"
+                action={
+                  <span className="text-xs font-semibold uppercase tracking-widest text-clay-500">
+                    ▶ Écouter
+                  </span>
+                }
+              />
             </div>
           </div>
 

--- a/src/pages/podcasts.tsx
+++ b/src/pages/podcasts.tsx
@@ -1,6 +1,7 @@
-import { Link, graphql, useStaticQuery } from 'gatsby';
+import { graphql, useStaticQuery } from 'gatsby';
 import React, { useMemo } from 'react';
 
+import { ContentCard } from '../components/content-card';
 import Layout from '../components/layout';
 import SEO from '../components/seo';
 import Text from '../components/text';
@@ -18,52 +19,35 @@ function EpisodeCard({ episode }: { episode: any }) {
   );
   const player = useAudioPlayer(audioPlayerData);
 
-  // Supprimer les balises HTML du résumé
   const plainSummary = episode.itunes.summary
     ? episode.itunes.summary.replace(/<[^>]*>/g, '').substring(0, 140) + '…'
     : '';
 
+  const meta = [
+    `Saison ${episode.itunes.season}`,
+    `Épisode ${episode.itunes.episode}`,
+    episode.itunes.duration,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+
   return (
-    <article className="group flex flex-col">
-      {/* Pochette */}
-      <Link
-        to={`/podcasts/${episode.guid}`}
-        className="block overflow-hidden rounded-sm"
-      >
-        <div className="aspect-square overflow-hidden bg-stone-100">
-          <img
-            src={episode.itunes.image}
-            alt={episode.title}
-            className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
-          />
-        </div>
-      </Link>
-
-      {/* Contenu */}
-      <div className="mt-4 flex flex-1 flex-col">
-        <p className="text-xs font-semibold uppercase tracking-widest text-clay-500">
-          Saison {episode.itunes.season} · Épisode {episode.itunes.episode}
-          {episode.itunes.duration && ` · ${episode.itunes.duration}`}
-        </p>
-
-        <Link to={`/podcasts/${episode.guid}`}>
-          <h2 className="mt-2 font-display text-xl font-semibold leading-snug text-stone-900 transition-colors hover:text-clay-500">
-            {episode.title}
-          </h2>
-        </Link>
-
-        <p className="mt-2 flex-1 text-sm leading-relaxed text-stone-500">
-          {plainSummary}
-        </p>
-
-        <div className="mt-4 flex items-center gap-3">
+    <ContentCard
+      href={`/podcasts/${episode.guid}`}
+      imageUrl={episode.itunes.image}
+      imageAlt={episode.title}
+      meta={meta}
+      title={episode.title}
+      description={plainSummary}
+      action={
+        <div className="flex items-center gap-3">
           <PlayButton player={player} size="small" />
           <span className="text-xs font-semibold uppercase tracking-widest text-clay-500">
             Écouter
           </span>
         </div>
-      </div>
-    </article>
+      }
+    />
   );
 }
 


### PR DESCRIPTION
## Summary

- **`content-card.tsx`** (nouveau) : composant partagé `ContentCard` avec structure identique — image `aspect-square` + `object-cover`, meta en eyebrow clay, titre en Cormorant, description, slot `action` libre
- **`podcasts.tsx`** : `EpisodeCard` utilise maintenant `ContentCard` avec un slot action PlayButton
- **`article-list.tsx`** : `ArticleCard` utilise maintenant `ContentCard` avec un slot action "Lire l'article →"
- **`design-system.tsx`** : section Cards mise à jour pour montrer les deux variantes avec le vrai composant

Les deux pages `/podcasts` et `/articles` ont maintenant **exactement la même structure de card** — seul le contenu du slot `action` diffère.

## Test plan

- [ ] `/podcasts` — cards identiques en structure aux cards articles
- [ ] `/articles` — cards identiques en structure aux cards podcasts
- [ ] `/design-system` — section Cards montre les 3 exemples ContentCard
- [ ] Hover zoom fonctionne sur les deux pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)