### PR TITLE
Redesign livres listing and book detail page

### DIFF
--- a/src/components/book-list.tsx
+++ b/src/components/book-list.tsx
@@ -1,8 +1,5 @@
 import { Link } from 'gatsby';
-import truncate from 'lodash/truncate';
 import React, { ReactElement } from 'react';
-
-import Text from './text';
 
 export interface BookProps {
   uid: string;
@@ -20,40 +17,44 @@ interface BookListItemProps {
   allBooks: BookProps[];
 }
 
-function BookItem({ book }: { book: BookProps }) {
+function BookItem({ book, index }: { book: BookProps; index: number }) {
   const slug = book.uid;
   const title = book.data.title.text;
   const content = book.data.content.text;
-  const truncatedContent = truncate(content, {
-    length: 190,
-  });
+  const excerpt =
+    content.length > 200 ? content.substring(0, 200) + '…' : content;
 
   return (
-    <>
-      <div className="book-item">
-        <Link
-          to={`/livres/${slug}`}
-          className="book-item-link hover:no-underline"
-        >
-          <Text as="h3" variant={'h3Link'}>
+    <article className="group border-b border-clay-200 py-8 last:border-0">
+      <Link to={`/livres/${slug}`} className="flex items-start gap-6">
+        {/* Numéro */}
+        <span className="mt-1 shrink-0 font-display text-3xl font-light text-clay-200 transition-colors group-hover:text-clay-300">
+          {String(index + 1).padStart(2, '0')}
+        </span>
+
+        {/* Contenu */}
+        <div className="flex-1">
+          <h2 className="font-display text-2xl font-semibold leading-snug text-stone-900 transition-colors group-hover:text-clay-500">
             {title}
-          </Text>
-          <p className="book-item-content text-gray-600">{truncatedContent}</p>
-        </Link>
-      </div>
-      <hr className="separator my-4" />
-    </>
+          </h2>
+          <p className="mt-3 text-sm leading-relaxed text-stone-500">
+            {excerpt}
+          </p>
+          <span className="mt-4 inline-block text-xs font-semibold uppercase tracking-widest text-clay-500 transition-colors group-hover:text-clay-700">
+            Lire la critique →
+          </span>
+        </div>
+      </Link>
+    </article>
   );
 }
 
-export default function BookList({
-  allBooks,
-}: BookListItemProps): ReactElement {
+export default function BookList({ allBooks }: BookListItemProps): ReactElement {
   return (
-    <>
+    <div className="m-auto mb-20 w-3/4">
       {allBooks.map((book, index) => (
-        <BookItem book={book} key={index} />
+        <BookItem book={book} key={book.uid} index={index} />
       ))}
-    </>
+    </div>
   );
 }

--- a/src/pages/livres.tsx
+++ b/src/pages/livres.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 
 import BookList, { BookProps } from '../components/book-list';
 import Layout from '../components/layout';
-import LayoutSidebar from '../components/layoutSidebar';
 import SEO from '../components/seo';
 
 interface BooksPageProps {
@@ -19,9 +18,20 @@ const BooksPage = ({ data }: BooksPageProps) => {
 
   return (
     <Layout withInstagram={false}>
-      <LayoutSidebar withPodcast={false}>
-        <BookList allBooks={allBooks} />
-      </LayoutSidebar>
+      {/* En-tête */}
+      <section className="m-auto mb-10 mt-8 w-3/4">
+        <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-clay-500">
+          Bibliothèque
+        </p>
+        <h1 className="font-display text-4xl font-semibold leading-tight text-stone-900 md:text-5xl">
+          Livres sur les femmes artistes
+        </h1>
+        <p className="mt-4 max-w-xl text-base leading-relaxed text-stone-500">
+          Une sélection de lectures pour explorer l'histoire des femmes dans l'art — biographies, essais, monographies.
+        </p>
+      </section>
+
+      <BookList allBooks={allBooks} />
     </Layout>
   );
 };
@@ -47,8 +57,8 @@ export const query = graphql`
 export const Head = () => {
   return (
     <SEO
-      title="Parcourez notre collection de livres sur les femmes artistes et leur contribution à l'art."
-      description="Découvrez des critiques littéraires exceptionnelles sur notre site ART au féminin. Plongez dans l'univers captivant des livres écrits par des femmes, où la créativité et la voix féminine sont mises en lumière"
+      title="Livres sur les femmes artistes — ART au féminin"
+      description="Une sélection de livres pour explorer l'histoire des femmes dans l'art — biographies, essais, monographies, critiques littéraires."
     />
   );
 };

--- a/src/templates/book.tsx
+++ b/src/templates/book.tsx
@@ -1,12 +1,10 @@
+import { StaticImage } from 'gatsby-plugin-image';
 import { RichTextBlock } from 'prismic-reactjs';
 import React, { ReactElement } from 'react';
 
-import Author from '../components/author';
 import { CustomRichText } from '../components/custom-rich-text';
 import Layout from '../components/layout';
 import SEO from '../components/seo';
-import Text from '../components/text';
-import Tipee from '../components/tipee';
 
 interface BookProps {
   pageContext: {
@@ -33,20 +31,73 @@ export default function Book(props: BookProps): ReactElement {
 
   return (
     <Layout>
-      <div className="m-auto max-w-3xl">
-        <header>
-          <Text as="h1" variant={'h1'} className="my-24">
+      {/* ── EN-TÊTE ──────────────────────────────────────────────── */}
+      <div className="border-b border-clay-200 pb-10 pt-16">
+        <div className="mx-auto max-w-3xl px-6 lg:px-0">
+          <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-clay-500">
+            Critique littéraire
+          </p>
+          <h1 className="font-display text-4xl font-semibold leading-tight text-stone-900 md:text-5xl lg:text-6xl">
             {seoTitle}
-          </Text>
-        </header>
+          </h1>
+        </div>
+      </div>
 
-        <article className="prose prose-xl prose-blue">
-          <div className="article-content mb-20">
-            <CustomRichText render={richText} />
+      {/* ── CONTENU ──────────────────────────────────────────────── */}
+      <div className="mx-auto max-w-3xl px-6 lg:px-0">
+        <div
+          className="prose prose-stone my-10 max-w-none prose-p:leading-relaxed prose-p:text-stone-600 prose-headings:font-display prose-headings:font-semibold prose-a:text-clay-500 prose-a:no-underline hover:prose-a:underline prose-img:rounded-sm"
+        >
+          <CustomRichText render={richText} />
+        </div>
+
+        <hr className="separator" />
+
+        {/* Autrice */}
+        <section className="my-10 flex items-center gap-6 rounded-sm border border-clay-200 bg-cream-50 p-6">
+          <div className="size-20 shrink-0 overflow-hidden rounded-full">
+            <StaticImage
+              src="../images/profile-picture.jpg"
+              alt="Aldjia Boughias — ART au féminin"
+              width={80}
+              height={80}
+              className="h-full w-full object-cover"
+            />
           </div>
-          <Tipee />
-          <Author />
-        </article>
+          <div>
+            <p className="mb-1 text-xs font-semibold uppercase tracking-widest text-clay-500">
+              À propos de l'autrice
+            </p>
+            <p className="text-sm leading-relaxed text-stone-600">
+              Bonjour, je suis Aldjia, créatrice et animatrice du podcast ART au féminin.
+              Je suis également l'autrice de ce blog — ravie de vous rencontrer !
+            </p>
+          </div>
+        </section>
+
+        {/* Mécénat */}
+        <section className="my-10 rounded-sm border border-clay-200 bg-cream-50 p-6">
+          <p className="mb-1 text-xs font-bold uppercase tracking-widest text-clay-500">
+            Mécénat
+          </p>
+          <h2 className="mb-3 font-display text-xl font-semibold text-stone-900">
+            Vous avez aimé cette critique ?
+          </h2>
+          <p className="mb-5 text-sm leading-relaxed text-stone-500">
+            Si ce contenu vous a plu, vous pouvez soutenir ART au féminin sur Tipeee.
+            Chaque contribution aide à produire de nouveaux épisodes et articles.
+          </p>
+          <a
+            href="https://fr.tipeee.com/art-au-feminin"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-full border border-clay-500 px-4 py-2 text-xs font-bold uppercase tracking-widest text-clay-500 transition-colors hover:bg-clay-500 hover:text-white"
+          >
+            Soutenir sur Tipeee
+          </a>
+        </section>
+
+        <div className="mb-20" />
       </div>
     </Layout>
   );
@@ -55,5 +106,10 @@ export default function Book(props: BookProps): ReactElement {
 export const Head = (props: BookProps) => {
   const { text: seoTitle } = props.pageContext.node.data.title;
   const { text: seoDescription } = props.pageContext.node.data.content;
-  return <SEO title={seoTitle} description={seoDescription} />;
+  return (
+    <SEO
+      title={`${seoTitle} — ART au féminin`}
+      description={seoDescription.substring(0, 155)}
+    />
+  );
 };


### PR DESCRIPTION
## Summary

- **`livres.tsx`**: suppression de `LayoutSidebar`, en-tête cohérent (eyebrow + H1 Cormorant + description introductive)
- **`book-list.tsx`**: format liste éditorial avec numérotation en grands chiffres Cormorant (01, 02…), titre en display, extrait, lien clay — adapté à l'absence d'images dans le schéma Prismic
- **`book.tsx`**: même structure que `article.tsx` — H1 centré avec eyebrow, prose `max-w-3xl`, card autrice, panel Tipeee

## Test plan

- [ ] `/livres` — liste numérotée avec hover clay sur le titre
- [ ] Clic sur un livre — en-tête + contenu centré + card autrice + Tipeee
- [ ] Cohérence visuelle avec `/articles` et `/podcasts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)