### PR TITLE
Rework livres page — book spine cards and chroniques

### DIFF
--- a/src/components/book-list.tsx
+++ b/src/components/book-list.tsx
@@ -17,41 +17,52 @@ interface BookListItemProps {
   allBooks: BookProps[];
 }
 
+const SPINE_COLORS = [
+  'bg-clay-300',
+  'bg-sage-300',
+  'bg-gold-300',
+  'bg-clay-200',
+  'bg-sage-500',
+  'bg-gold-500',
+  'bg-clay-500',
+  'bg-sage-300',
+];
+
 function BookItem({ book, index }: { book: BookProps; index: number }) {
   const slug = book.uid;
   const title = book.data.title.text;
   const content = book.data.content.text;
   const excerpt =
-    content.length > 200 ? content.substring(0, 200) + '…' : content;
+    content.length > 160 ? content.substring(0, 160) + '…' : content;
+  const spineColor = SPINE_COLORS[index % SPINE_COLORS.length];
 
   return (
-    <article className="group border-b border-clay-200 py-8 last:border-0">
-      <Link to={`/livres/${slug}`} className="flex items-start gap-6">
-        {/* Numéro */}
-        <span className="mt-1 shrink-0 font-display text-3xl font-light text-clay-200 transition-colors group-hover:text-clay-300">
-          {String(index + 1).padStart(2, '0')}
-        </span>
+    <Link
+      to={`/livres/${slug}`}
+      className="group flex overflow-hidden rounded-sm border border-clay-200 bg-cream-50 transition-shadow hover:shadow-md"
+    >
+      {/* Dos du livre */}
+      <div className={`w-3 shrink-0 ${spineColor} transition-all duration-300 group-hover:w-4`} />
 
-        {/* Contenu */}
-        <div className="flex-1">
-          <h2 className="font-display text-2xl font-semibold leading-snug text-stone-900 transition-colors group-hover:text-clay-500">
-            {title}
-          </h2>
-          <p className="mt-3 text-sm leading-relaxed text-stone-500">
-            {excerpt}
-          </p>
-          <span className="mt-4 inline-block text-xs font-semibold uppercase tracking-widest text-clay-500 transition-colors group-hover:text-clay-700">
-            Lire la critique →
-          </span>
-        </div>
-      </Link>
-    </article>
+      {/* Contenu */}
+      <div className="flex flex-1 flex-col p-6">
+        <h2 className="font-display text-xl font-semibold leading-snug text-stone-900 transition-colors group-hover:text-clay-500">
+          {title}
+        </h2>
+        <p className="mt-3 flex-1 text-sm leading-relaxed text-stone-500">
+          {excerpt}
+        </p>
+        <span className="mt-5 text-xs font-semibold uppercase tracking-widest text-clay-500 transition-colors group-hover:text-clay-700">
+          Lire la chronique →
+        </span>
+      </div>
+    </Link>
   );
 }
 
 export default function BookList({ allBooks }: BookListItemProps): ReactElement {
   return (
-    <div className="m-auto mb-20 w-3/4">
+    <div className="m-auto mb-20 grid w-3/4 grid-cols-1 gap-6 sm:grid-cols-2">
       {allBooks.map((book, index) => (
         <BookItem book={book} key={book.uid} index={index} />
       ))}

--- a/src/pages/livres.tsx
+++ b/src/pages/livres.tsx
@@ -27,7 +27,7 @@ const BooksPage = ({ data }: BooksPageProps) => {
           Livres sur les femmes artistes
         </h1>
         <p className="mt-4 max-w-xl text-base leading-relaxed text-stone-500">
-          Une sélection de lectures pour explorer l'histoire des femmes dans l'art — biographies, essais, monographies.
+          Une sélection de chroniques pour explorer l'histoire des femmes dans l'art — biographies, essais, monographies.
         </p>
       </section>
 
@@ -58,7 +58,7 @@ export const Head = () => {
   return (
     <SEO
       title="Livres sur les femmes artistes — ART au féminin"
-      description="Une sélection de livres pour explorer l'histoire des femmes dans l'art — biographies, essais, monographies, critiques littéraires."
+      description="Une sélection de chroniques pour explorer l'histoire des femmes dans l'art — biographies, essais, monographies."
     />
   );
 };

--- a/src/templates/book.tsx
+++ b/src/templates/book.tsx
@@ -35,7 +35,7 @@ export default function Book(props: BookProps): ReactElement {
       <div className="border-b border-clay-200 pb-10 pt-16">
         <div className="mx-auto max-w-3xl px-6 lg:px-0">
           <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-clay-500">
-            Critique littéraire
+            Chronique
           </p>
           <h1 className="font-display text-4xl font-semibold leading-tight text-stone-900 md:text-5xl lg:text-6xl">
             {seoTitle}
@@ -81,7 +81,7 @@ export default function Book(props: BookProps): ReactElement {
             Mécénat
           </p>
           <h2 className="mb-3 font-display text-xl font-semibold text-stone-900">
-            Vous avez aimé cette critique ?
+            Vous avez aimé cette chronique ?
           </h2>
           <p className="mb-5 text-sm leading-relaxed text-stone-500">
             Si ce contenu vous a plu, vous pouvez soutenir ART au féminin sur Tipeee.


### PR DESCRIPTION
## Summary

- **`book-list.tsx`**: nouvelle mise en page grille 2 colonnes — cards avec bande colorée à gauche (dos de livre) en clay/sage/gold alternés, s'élargit au hover, fond crème, titre Cormorant, extrait, CTA "Lire la chronique →"
- **`livres.tsx`**: description mise à jour avec le mot "chroniques"
- **`book.tsx`**: "Critique littéraire" → "Chronique" partout dans le template détail

## Test plan

- [ ] `/livres` — grille 2 colonnes avec bandes colorées
- [ ] Hover — bande s'élargit, titre passe en clay
- [ ] Page détail — eyebrow affiche "Chronique"

🤖 Generated with [Claude Code](https://claude.com/claude-code)