### PR TITLE
Redesign Mon histoire — about page for Aldjia Boughias

### DIFF
--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -1,94 +1,164 @@
+import { StaticImage } from 'gatsby-plugin-image';
 import React from 'react';
 
-import Author from '../components/author';
 import Layout from '../components/layout';
 import SEO from '../components/seo';
-import Text from '../components/text';
 
 export default function AboutPage() {
   return (
-    <Layout>
-      <article className="m-auto max-w-2xl">
-        <div>
-          <Text as="h2" variant={'h2about'}>
-            Mon histoire
-          </Text>
-          <Text as="p" variant={'pAbout'}>
-            Pour ma part, je vous propose de revenir sur certaines périodes de
-            l’histoire de l’art, plus particulièrement sur{' '}
-            <strong className="font-extrabold">
-              l’histoire des femmes artistes
-            </strong>
-            .
-          </Text>
+    <Layout withInstagram={false}>
 
-          <Text as="p" variant={'pAbout'}>
-            Avec ART au féminin, j’invite des directrices, conservatrices de
-            musées, des historiennes de l’art… à nous parler de femmes artistes.
-            Et ainsi, revenir sur l’histoire et les oeuvres de ces femmes qui
-            ont marquées l’histoire de l’art. Des femmes pour la plupart
-            oubliées.
-          </Text>
+      {/* ── EN-TÊTE ──────────────────────────────────────────────── */}
+      <section className="m-auto mb-16 mt-8 w-3/4">
+        <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-clay-500">
+          Mon histoire
+        </p>
+        <h1 className="font-display text-4xl font-semibold leading-tight text-stone-900 md:text-5xl">
+          Aldjia Boughias
+        </h1>
+      </section>
 
-          <Text as="p" variant={'pAbout'}>
-            J’invite aussi des{' '}
-            <strong className="font-extrabold">
-              femmes artistes d’aujourd’hui
-            </strong>{' '}
-            à témoigner sur leur parcours, leur travail, et donner leur point de
-            vue sur la place des femmes artistes dans le monde de l’art.
-          </Text>
+      {/* ── PORTRAIT + INTRO ─────────────────────────────────────── */}
+      <section className="m-auto mb-16 w-3/4">
+        <div className="flex flex-col gap-10 md:flex-row md:items-start md:gap-16">
 
-          <blockquote className="m-auto -mx-52 mb-12 items-center py-12 text-center">
-            <Text as="h2" variant={'h2about'}>
+          {/* Photo */}
+          <div className="shrink-0 md:w-64">
+            <div className="overflow-hidden rounded-sm">
+              <StaticImage
+                src="../images/profile-picture.jpg"
+                alt="Aldjia Boughias — créatrice d'ART au féminin"
+                width={320}
+                height={400}
+                className="w-full object-cover object-top"
+              />
+            </div>
+            <div className="mt-4 rounded-sm border border-clay-200 bg-cream-50 p-4">
+              <p className="text-xs font-semibold uppercase tracking-widest text-clay-500">
+                Lille, France
+              </p>
+              <p className="mt-1 text-sm text-stone-600">
+                Passionnée d'art · Beaux-Arts · Développeuse web
+              </p>
+            </div>
+          </div>
+
+          {/* Texte */}
+          <div className="flex-1 space-y-6">
+            <p className="font-display text-2xl font-light italic leading-relaxed text-stone-700">
+              Je suis Aldjia, créatrice et animatrice du podcast ART au féminin.
+              Formée aux Beaux-Arts et au développement web, je mets mes deux passions
+              au service d'un même projet : rendre visibles les femmes artistes.
+            </p>
+            <p className="text-base leading-relaxed text-stone-600">
+              Avec ART au féminin, je vous propose de revenir sur certaines périodes
+              de l'histoire de l'art — plus particulièrement sur l'histoire des
+              <strong className="font-semibold text-stone-800"> femmes artistes</strong>.
+              J'invite des directrices de musées, des conservatrices, des historiennes
+              de l'art à nous parler de ces femmes qui ont marqué l'histoire mais
+              ont été, pour la plupart, oubliées.
+            </p>
+            <p className="text-base leading-relaxed text-stone-600">
+              J'invite aussi des{' '}
+              <strong className="font-semibold text-stone-800">femmes artistes d'aujourd'hui</strong>{' '}
+              à témoigner de leur parcours, de leur travail, et à donner leur point
+              de vue sur la place des femmes dans le monde de l'art.
+            </p>
+            <p className="text-base leading-relaxed text-stone-600">
+              ART au féminin, c'est des podcasts, des articles, des chroniques de
+              livres et des citations — tout ce qui permet de retracer et de célébrer
+              l'histoire des femmes artistes.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* ── CITATION BEAUVOIR ────────────────────────────────────── */}
+      <section className="border-y border-clay-200 bg-cream-200 py-16">
+        <div className="mx-auto max-w-3xl px-6 lg:px-0">
+          <span
+            className="block font-display text-8xl font-light leading-none text-clay-300"
+            aria-hidden="true"
+          >
+            «
+          </span>
+          <blockquote className="mt-2">
+            <p className="font-display text-xl font-light italic leading-relaxed text-stone-700 md:text-2xl">
               Nous commencerons par discuter les points de vue pris sur la femme
               par la biologie, la psychanalyse, le matérialisme historique. Nous
-              essaierons de monter ensuite positivement comment la réalité
-              féminine s’est constituée, pourquoi la femme a été définie comme
-              l’Autre et quelles en ont été les conséquences du point de vue des
-              hommes. Alors nous décrirons du point de vue des femmes le monde
-              tel qu’il leur est proposé, et nous pourrons comprendre a quelles
-              difficultés elles se heurtent au moment où, essayant de s’évader
-              de la sphère qui leur a été jusqu’a présent assignée, elles
-              prétendent participer au mitsein humain
-            </Text>
-            <Text as="h2" variant={'h2about'}>
-              <cite>—Simone de Beauvoir</cite>
-            </Text>
+              essaierons de monter ensuite positivement comment la réalité féminine
+              s'est constituée, pourquoi la femme a été définie comme l'Autre et
+              quelles en ont été les conséquences du point de vue des hommes.
+            </p>
+            <footer className="mt-6">
+              <cite className="text-xs font-semibold uppercase tracking-widest text-clay-500 not-italic">
+                — Simone de Beauvoir
+              </cite>
+            </footer>
           </blockquote>
-
-          <Text as="p" variant={'pAbout'}>
-            ART au féminin, c’est des podcasts, mais pas que. Vous y trouverez
-            des articles et le partage de certaines lectures.
-          </Text>
-
-          <Text as="h2" variant={'h2about'}>
-            Pourquoi ?
-          </Text>
-
-          <Text as="p" variant={'pAbout'}>
-            <ul className="list-inside list-disc leading-relaxed">
-              <li>
-                Car je suis une passionnée d’art, une amoureuse du partage.
-              </li>
-              <li>
-                J’entend souvent parler d’hommes artistes et beaucoup moins de
-                femmes artistes.
-              </li>
-              <li>Car le monde regorge de talentueuses femmes artistes.</li>
-              <li>Car on en parle jamais trop,</li>
-              <li>Car va va nous enrichir culturellement. </li>
-            </ul>
-          </Text>
-          <Text as="p" variant={'pAbout'}>
-            Ici je vous propose de retracer l’histoire des femmes artistes !
-          </Text>
         </div>
+      </section>
 
-        <div className="my-24">
-          <Author />
+      {/* ── POURQUOI ─────────────────────────────────────────────── */}
+      <section className="m-auto my-16 w-3/4">
+        <div className="grid grid-cols-1 gap-10 md:grid-cols-2">
+
+          <div>
+            <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-clay-500">
+              Pourquoi ce podcast ?
+            </p>
+            <h2 className="mb-6 font-display text-3xl font-semibold leading-snug text-stone-900">
+              Parce que le monde regorge de femmes artistes talentueuses.
+            </h2>
+          </div>
+
+          <ul className="space-y-4">
+            {[
+              "Car je suis passionnée d'art et amoureuse du partage.",
+              "Car on entend trop souvent parler d'hommes artistes, et beaucoup trop peu de femmes.",
+              "Car le monde regorge de femmes artistes talentueuses.",
+              "Car on n'en parle jamais assez.",
+              "Car cela nous enrichit culturellement.",
+            ].map((reason) => (
+              <li key={reason} className="flex items-start gap-3">
+                <span className="mt-1 size-1.5 shrink-0 rounded-full bg-clay-500" />
+                <span className="text-base leading-relaxed text-stone-600">
+                  {reason}
+                </span>
+              </li>
+            ))}
+          </ul>
         </div>
-      </article>
+      </section>
+
+      {/* ── CTA ──────────────────────────────────────────────────── */}
+      <section className="m-auto mb-20 w-3/4">
+        <div className="flex flex-col gap-4 rounded-sm border border-clay-200 bg-cream-50 p-8 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="mb-1 text-xs font-semibold uppercase tracking-widest text-clay-500">
+              Commencer l'aventure
+            </p>
+            <p className="font-display text-xl font-semibold text-stone-900">
+              Écoutez le premier épisode
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <a
+              href="/podcasts"
+              className="inline-flex items-center gap-2 rounded-full border border-clay-500 px-5 py-2.5 text-xs font-bold uppercase tracking-widest text-clay-500 transition-colors hover:bg-clay-500 hover:text-white"
+            >
+              Tous les épisodes
+            </a>
+            <a
+              href="/articles"
+              className="inline-flex items-center gap-2 rounded-full border border-stone-300 px-5 py-2.5 text-xs font-bold uppercase tracking-widest text-stone-600 transition-colors hover:border-stone-500 hover:text-stone-900"
+            >
+              Les articles
+            </a>
+          </div>
+        </div>
+      </section>
+
     </Layout>
   );
 }
@@ -96,8 +166,8 @@ export default function AboutPage() {
 export const Head = () => {
   return (
     <SEO
-      title="À propos: découvrez qui je suis et les projets chez ART au féminin."
-      description="à l’origine du projet, une question simple : combien existe-t-il de femme artistes dans les musées. La réponse est difficile à trouver voire impossible sans recherches approfondies que vous pourrez découvrir en écoutant le podcast."
+      title="Mon histoire — Aldjia Boughias, créatrice d'ART au féminin"
+      description="Je suis Aldjia Boughias, créatrice du podcast ART au féminin. Formée aux Beaux-Arts, je mets ma passion de l'art au service de la visibilité des femmes artistes."
     />
   );
 };


### PR DESCRIPTION
## Summary

Refonte complète de la page `/about` avec une vraie mise en page biographique :

- **Portrait + carte identité** : photo d'Aldjia, localisation Lille, formation Beaux-Arts + dev
- **Intro en Cormorant** : phrase d'accroche en italique, puis paragraphes biographiques sur la démarche du podcast
- **Citation Simone de Beauvoir** : bande pleine largeur `bg-cream-200`, grand guillemet décoratif, citation en display italic
- **Section Pourquoi** : 2 colonnes — titre fort à gauche, liste avec points clay à droite
- **CTA** : panel avec liens vers podcasts et articles

Informations biographiques tirées de aldjia.dev.

## Test plan

- [ ] `/about` — layout portrait + texte s'affiche correctement
- [ ] Photo bien cadrée (object-top)
- [ ] Section Beauvoir pleine largeur visible
- [ ] CTA liens fonctionnels

🤖 Generated with [Claude Code](https://claude.com/claude-code)