### PR TITLE
Complete site audit — galerie, 404, FAQ, presse, Open Graph, nav

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -13,6 +13,7 @@ const navigation = {
     { name: 'Articles', href: '/articles' },
     { name: 'Livres & chroniques', href: '/livres' },
     { name: 'Citations', href: '/citations' },
+    { name: 'Galerie 3D', href: '/galerie' },
   ],
   podcast: [
     { name: 'Toutes les plateformes', href: '/links' },

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -8,6 +8,7 @@ const navigation = [
   { name: 'Articles', href: '/articles' },
   { name: 'Livres', href: '/livres' },
   { name: 'Citations', href: '/citations' },
+  { name: 'Galerie', href: '/galerie' },
   { name: 'Contact', href: 'mailto:artaufemininlepodcast@gmail.com', isExternal: true },
 ];
 

--- a/src/components/pressList.tsx
+++ b/src/components/pressList.tsx
@@ -1,20 +1,12 @@
 import * as React from 'react';
 import { ReactElement } from 'react';
 
-import Text from './text';
-
 interface PressProps {
   uid: string;
   data: {
-    description: {
-      text: string;
-    };
-    sitename: {
-      text: string;
-    };
-    url: {
-      url: string;
-    };
+    description: { text: string };
+    sitename: { text: string };
+    url: { url: string };
   };
 }
 
@@ -22,30 +14,33 @@ interface PressItemProps {
   allPress: PressProps[];
 }
 
-const PressItem = ({ pressItem }: { pressItem: PressProps }) => {
-  return (
-    <ul className="py-2">
-      <li className="flex py-4 leading-6">
-        <Text as="h3" variant={'h3'}>
-          <a
-            href={pressItem.data.url.url}
-            className="mb-4 text-lg text-blue-500"
-          >
-            <strong>{pressItem.data.sitename.text}</strong>
-          </a>
-          : {pressItem.data.description.text}
-        </Text>
-      </li>
-    </ul>
-  );
-};
+const PressItem = ({ pressItem }: { pressItem: PressProps }) => (
+  <a
+    href={pressItem.data.url.url}
+    target="_blank"
+    rel="noopener noreferrer"
+    className="group flex items-start gap-4 rounded-sm border border-clay-200 bg-cream-50 p-5 transition-all hover:border-clay-400 hover:shadow-sm"
+  >
+    <div className="flex-1">
+      <p className="font-display text-lg font-semibold text-stone-900 transition-colors group-hover:text-clay-500">
+        {pressItem.data.sitename.text}
+      </p>
+      <p className="mt-1 text-sm leading-relaxed text-stone-500">
+        {pressItem.data.description.text}
+      </p>
+    </div>
+    <span className="mt-1 shrink-0 text-clay-300 transition-transform group-hover:translate-x-0.5 group-hover:text-clay-500">
+      →
+    </span>
+  </a>
+);
 
 export default function PressList({ allPress }: PressItemProps): ReactElement {
   return (
-    <>
-      {allPress.map((pressItem) => {
-        return <PressItem pressItem={pressItem} key={pressItem.uid} />;
-      })}
-    </>
+    <div className="space-y-3">
+      {allPress.map((pressItem, index) => (
+        <PressItem pressItem={pressItem} key={pressItem.uid ?? index} />
+      ))}
+    </div>
   );
 }

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -1,12 +1,17 @@
 import { graphql, useStaticQuery } from 'gatsby';
 import React from 'react';
 
+const OG_IMAGE =
+  'https://raw.githubusercontent.com/flexbox/artaufeminin/master/src/images/logo-podcast-art-au-feminin.png';
+
 export function SeoHead({
   title,
   metaDescription,
+  image = OG_IMAGE,
 }: {
   title: string;
   metaDescription: string;
+  image?: string;
 }) {
   return (
     <>
@@ -16,14 +21,33 @@ export function SeoHead({
         name="google-site-verification"
         content="_I5e7rtsxD_MXi3RnD2AsbiQopSHnXHQ_eEAKQYuLPk"
       />
+      {/* Open Graph */}
       <meta property="og:title" content={title} />
       <meta property="og:description" content={metaDescription} />
       <meta property="og:type" content="website" />
+      <meta property="og:image" content={image} />
+      <meta property="og:image:width" content="1200" />
+      <meta property="og:image:height" content="630" />
+      <meta property="og:locale" content="fr_FR" />
+      <meta property="og:site_name" content="ART au féminin" />
+      {/* Twitter / X */}
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={metaDescription} />
+      <meta name="twitter:image" content={image} />
     </>
   );
 }
 
-function SEO({ description, title }: { description: string; title: string }) {
+function SEO({
+  description,
+  title,
+  image,
+}: {
+  description: string;
+  title: string;
+  image?: string;
+}) {
   const { site } = useStaticQuery(graphql`
     query {
       site {
@@ -36,7 +60,9 @@ function SEO({ description, title }: { description: string; title: string }) {
     }
   `);
   const metaDescription = description || site.siteMetadata.description;
-  return <SeoHead title={title} metaDescription={metaDescription} />;
+  return (
+    <SeoHead title={title} metaDescription={metaDescription} image={image} />
+  );
 }
 
 SEO.defaultProps = {

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'gatsby';
 import React, { ReactElement } from 'react';
 
 import Layout from '../components/layout';
@@ -5,22 +6,60 @@ import SEO from '../components/seo';
 
 export default function NotFoundPage(): ReactElement {
   return (
-    <Layout>
-      <div className="mx-auto max-w-7xl">
-        <div className="my-32">
-          <h1>Ohoh. Il n'y a rien à voir ici.</h1>
-          <p>La page que vous demandez n'existe pas.</p>
+    <Layout withInstagram={false}>
+      <div className="mx-auto max-w-2xl px-6 py-24 text-center lg:px-0">
+
+        {/* Numéro décoratif */}
+        <p className="font-display text-[8rem] font-light leading-none text-clay-200 md:text-[12rem]">
+          404
+        </p>
+
+        <h1 className="mt-2 font-display text-3xl font-semibold text-stone-900 md:text-4xl">
+          Cette page n'existe pas
+        </h1>
+        <p className="mx-auto mt-4 max-w-md text-base leading-relaxed text-stone-500">
+          La page que vous cherchez a peut-être été déplacée ou supprimée.
+          Voici quelques liens pour retrouver votre chemin.
+        </p>
+
+        {/* Liens principaux */}
+        <div className="mt-10 flex flex-wrap justify-center gap-3">
+          <Link
+            to="/"
+            className="rounded-full bg-clay-500 px-6 py-3 text-xs font-bold uppercase tracking-widest text-white transition-colors hover:bg-clay-700"
+          >
+            Accueil
+          </Link>
+          <Link
+            to="/podcasts"
+            className="rounded-full border border-clay-500 px-6 py-3 text-xs font-bold uppercase tracking-widest text-clay-500 transition-colors hover:bg-clay-500 hover:text-white"
+          >
+            Les podcasts
+          </Link>
+          <Link
+            to="/articles"
+            className="rounded-full border border-clay-200 px-6 py-3 text-xs font-bold uppercase tracking-widest text-stone-600 transition-colors hover:border-clay-400 hover:text-clay-500"
+          >
+            Les articles
+          </Link>
         </div>
+
+        {/* Séparateur */}
+        <hr className="separator mx-auto mt-16 max-w-xs" />
+
+        {/* Citation de consolation */}
+        <p className="mt-8 font-display text-lg font-light italic text-stone-400">
+          « L'art, c'est aussi savoir se perdre pour mieux se retrouver. »
+        </p>
+
       </div>
     </Layout>
   );
 }
 
-export const Head = () => {
-  return (
-    <SEO
-      title="404: Not Found"
-      description="Découvrez l'univers de l'art sur ART au féminin. Bien que cette page puisse être une impasse, nos trésors artistiques vous attendent juste au coin de la rue. Explorez notre collection diversifiée et laissez la créativité guider votre parcours."
-    />
-  );
-};
+export const Head = () => (
+  <SEO
+    title="Page introuvable — ART au féminin"
+    description="La page que vous cherchez n'existe pas. Découvrez le podcast ART au féminin et ses contenus sur les femmes artistes."
+  />
+);

--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -1,6 +1,6 @@
 import { graphql } from 'gatsby';
 import { RichText, RichTextBlock } from 'prismic-reactjs';
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useState } from 'react';
 
 import Layout from '../components/layout';
 import SEO from '../components/seo';
@@ -8,25 +8,40 @@ import SEO from '../components/seo';
 interface FaqPageProps {
   data: {
     allPrismicFaq: {
-      nodes: [
-        {
-          data: {
-            question: string;
-            answer: RichTextBlock[];
-          };
-        },
-      ];
+      nodes: {
+        data: {
+          question: { text: string };
+          answer: { richText: RichTextBlock[] };
+        };
+      }[];
     };
   };
 }
 
-function QuestionItem({ question }): ReactElement {
+function QuestionItem({ question, defaultOpen = false }: { question: FaqPageProps['data']['allPrismicFaq']['nodes'][0]; defaultOpen?: boolean }) {
+  const [open, setOpen] = useState(defaultOpen);
+
   return (
-    <>
-      <h2>{question.data.question.text}</h2>
-      <div>{RichText.render(question.data.answer.richText)}</div>
-      <hr className="separator" />
-    </>
+    <div className="border-b border-clay-200 last:border-0">
+      <button
+        className="flex w-full items-start justify-between gap-6 py-6 text-left"
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+      >
+        <h2 className="font-display text-lg font-semibold leading-snug text-stone-900">
+          {question.data.question.text}
+        </h2>
+        <span className="mt-0.5 shrink-0 text-clay-400 transition-transform duration-200" style={{ transform: open ? 'rotate(45deg)' : 'rotate(0deg)' }}>
+          +
+        </span>
+      </button>
+
+      {open && (
+        <div className="prose prose-stone mb-6 max-w-none prose-p:leading-relaxed prose-p:text-stone-600 prose-a:text-clay-500 prose-a:no-underline hover:prose-a:underline">
+          {RichText.render(question.data.answer.richText)}
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -34,17 +49,49 @@ export default function FaqPage({ data }: FaqPageProps): ReactElement {
   const questions = data.allPrismicFaq.nodes;
 
   return (
-    <Layout>
-      <article className="prose m-auto">
-        <div>
-          <h1>Questions fréquentes</h1>
+    <Layout withInstagram={false}>
+
+      {/* En-tête */}
+      <section className="m-auto mb-12 mt-8 w-3/4">
+        <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-clay-500">
+          Aide
+        </p>
+        <h1 className="font-display text-4xl font-semibold leading-tight text-stone-900 md:text-5xl">
+          Questions fréquentes
+        </h1>
+        <p className="mt-4 max-w-xl text-base leading-relaxed text-stone-500">
+          Vous avez une question sur le podcast ou sur ART au féminin ?
+          Retrouvez les réponses ci-dessous.
+        </p>
+      </section>
+
+      {/* Liste des questions */}
+      <div className="m-auto mb-16 w-3/4 rounded-sm border border-clay-200 bg-cream-50 px-8">
+        {questions.map((question, index) => (
+          <QuestionItem key={index} question={question} defaultOpen={index === 0} />
+        ))}
+      </div>
+
+      {/* CTA contact */}
+      <section className="m-auto mb-20 w-3/4">
+        <div className="flex flex-col gap-4 rounded-sm border border-clay-200 bg-cream-50 p-8 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="mb-1 text-xs font-semibold uppercase tracking-widest text-clay-500">
+              Vous ne trouvez pas votre réponse ?
+            </p>
+            <p className="font-display text-xl font-semibold text-stone-900">
+              Contactez-nous directement
+            </p>
+          </div>
+          <a
+            href="mailto:artaufemininlepodcast@gmail.com"
+            className="inline-flex items-center gap-2 rounded-full border border-clay-500 px-5 py-2.5 text-xs font-bold uppercase tracking-widest text-clay-500 transition-colors hover:bg-clay-500 hover:text-white"
+          >
+            Envoyer un email →
+          </a>
         </div>
-        <div>
-          {questions.map((question, index) => {
-            return <QuestionItem key={index} question={question} />;
-          })}
-        </div>
-      </article>
+      </section>
+
     </Layout>
   );
 }
@@ -67,11 +114,9 @@ export const pageQuery = graphql`
   }
 `;
 
-export const Head = () => {
-  return (
-    <SEO
-      title="Trouvez des réponses à vos questions les plus fréquentes sur le podcast ART au féminin."
-      description="Conseils et réponses sur le podcast."
-    />
-  );
-};
+export const Head = () => (
+  <SEO
+    title="Questions fréquentes — ART au féminin"
+    description="Toutes les réponses à vos questions sur le podcast ART au féminin — comment écouter, participer, soutenir le projet et en savoir plus sur les femmes artistes."
+  />
+);

--- a/src/pages/galerie.tsx
+++ b/src/pages/galerie.tsx
@@ -1,0 +1,209 @@
+import { Link } from 'gatsby';
+import React, { ReactElement } from 'react';
+
+import Layout from '../components/layout';
+import SEO from '../components/seo';
+
+export default function GaleriePage(): ReactElement {
+  return (
+    <Layout withInstagram={false}>
+
+      {/* ── HERO SOMBRE ──────────────────────────────────────────── */}
+      <section className="-mx-4 -mt-12 bg-stone-900">
+        <div className="mx-auto max-w-7xl px-6 py-24 lg:flex lg:items-center lg:gap-20 lg:px-16 lg:py-36">
+
+          {/* Texte */}
+          <div className="flex-1">
+            <p className="mb-4 text-xs font-semibold uppercase tracking-widest text-clay-300">
+              Bientôt disponible
+            </p>
+            <h1 className="font-display text-5xl font-semibold leading-tight text-white md:text-6xl lg:text-7xl">
+              Galerie{' '}
+              <span className="italic font-light text-clay-300">
+                ART au féminin
+              </span>
+            </h1>
+            <p className="mt-4 font-display text-2xl font-light italic text-stone-400 md:text-3xl">
+              Première exposition — « Sororité »
+            </p>
+            <p className="mt-6 max-w-lg text-base leading-relaxed text-stone-400">
+              Une galerie d'art immersive en 3D entièrement dédiée aux femmes
+              artistes. Explorez les œuvres, découvrez les parcours, ressentez
+              l'art — depuis chez vous.
+            </p>
+            <div className="mt-10 flex flex-wrap gap-4">
+              <Link
+                to="/newsletter"
+                className="inline-flex items-center gap-2 rounded-full bg-clay-500 px-6 py-3 text-xs font-bold uppercase tracking-widest text-white transition-colors hover:bg-clay-700"
+              >
+                Être informée en avant-première →
+              </Link>
+            </div>
+          </div>
+
+          {/* Visuel orbital */}
+          <div className="mt-16 flex justify-center lg:mt-0 lg:shrink-0">
+            <div className="relative flex items-center justify-center" style={{ width: 320, height: 320 }}>
+              <div className="absolute size-80 rounded-full border border-white/5" />
+              <div className="absolute size-64 rounded-full border border-white/8" />
+              <div className="absolute size-48 rounded-full border border-clay-500/20" />
+              <div className="absolute size-32 rounded-full border border-clay-500/30" />
+
+              <div className="relative flex size-20 items-center justify-center rounded-full border border-clay-500/50 bg-stone-800">
+                <span className="font-display text-3xl font-light italic text-clay-300">✦</span>
+              </div>
+
+              {[0,1,2,3,4,5,6,7].map((i) => {
+                const angle = (i / 8) * 360;
+                const rad = (angle * Math.PI) / 180;
+                const x = Math.cos(rad) * 90;
+                const y = Math.sin(rad) * 90;
+                return (
+                  <div key={i} className="absolute size-2 rounded-full bg-clay-400/70"
+                    style={{ transform: `translate(${x}px, ${y}px)` }} />
+                );
+              })}
+              {[0,1,2,3,4,5,6,7,8,9,10,11].map((i) => {
+                const angle = (i / 12) * 360 + 15;
+                const rad = (angle * Math.PI) / 180;
+                const x = Math.cos(rad) * 118;
+                const y = Math.sin(rad) * 118;
+                return (
+                  <div key={i} className="absolute size-1.5 rounded-full bg-stone-500/60"
+                    style={{ transform: `translate(${x}px, ${y}px)` }} />
+                );
+              })}
+              {[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19].map((i) => {
+                const angle = (i / 20) * 360 + 7;
+                const rad = (angle * Math.PI) / 180;
+                const x = Math.cos(rad) * 148;
+                const y = Math.sin(rad) * 148;
+                return (
+                  <div key={i} className="absolute size-1 rounded-full bg-stone-600/50"
+                    style={{ transform: `translate(${x}px, ${y}px)` }} />
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── CONCEPT ──────────────────────────────────────────────── */}
+      <section className="mx-auto my-20 max-w-3xl px-6 lg:px-0">
+        <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-clay-500">
+          Le projet
+        </p>
+        <h2 className="mb-8 font-display text-3xl font-semibold leading-snug text-stone-900 md:text-4xl">
+          Une galerie virtuelle pour rendre visibles les femmes artistes
+        </h2>
+        <div className="space-y-5 text-base leading-relaxed text-stone-600">
+          <p>
+            La Galerie ART au féminin est une galerie d'art immersive en 3D,
+            conçue pour faire découvrir les œuvres de femmes artistes au plus
+            grand nombre. Une expérience culturelle accessible à toutes,
+            partout dans le monde, sans barrière géographique.
+          </p>
+          <p>
+            Chaque exposition réunit des artistes autour d'un thème commun.
+            On y explore leurs œuvres, on lit leurs histoires, on comprend
+            leur démarche — comme dans une vraie galerie, mais en ligne.
+          </p>
+        </div>
+      </section>
+
+      {/* ── EXPOSITION SORORITÉ ───────────────────────────────────── */}
+      <section className="border-y border-clay-200 bg-cream-200 py-16">
+        <div className="mx-auto max-w-5xl px-6 lg:px-0">
+          <div className="lg:flex lg:items-start lg:gap-16">
+
+            <div className="lg:w-1/2">
+              <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-clay-500">
+                Première exposition
+              </p>
+              <h2 className="font-display text-4xl font-semibold leading-tight text-stone-900 md:text-5xl">
+                « Sororité »
+              </h2>
+              <p className="mt-4 font-display text-xl font-light italic leading-relaxed text-stone-600">
+                Ce lien puissant entre femmes qui traverse l'histoire de l'art
+                depuis des siècles — enfin mis en lumière.
+              </p>
+              <p className="mt-5 text-base leading-relaxed text-stone-600">
+                La première exposition de la Galerie ART au féminin réunit
+                une vingtaine d'artistes autour du thème de la sororité —
+                ces liens de solidarité, d'entraide et de reconnaissance
+                mutuelle entre femmes créatrices.
+              </p>
+            </div>
+
+            <div className="mt-10 lg:mt-0 lg:w-1/2">
+              <div className="grid grid-cols-2 gap-4">
+                {[
+                  { label: '~20 artistes', desc: 'De différentes époques et origines' },
+                  { label: 'Immersif 3D', desc: 'Une expérience de visite unique' },
+                  { label: 'Gratuit', desc: 'Accessible à toutes et à tous' },
+                  { label: 'En ligne', desc: 'Sans frontières géographiques' },
+                ].map(({ label, desc }) => (
+                  <div key={label} className="rounded-sm border border-clay-200 bg-cream-50 p-5">
+                    <p className="font-display text-2xl font-semibold text-stone-900">{label}</p>
+                    <p className="mt-1 text-xs leading-relaxed text-stone-500">{desc}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── NEWSLETTER CTA ───────────────────────────────────────── */}
+      <section className="mx-auto my-20 max-w-xl px-6 text-center lg:px-0">
+        <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-clay-500">
+          Restez informée
+        </p>
+        <h2 className="mb-4 font-display text-3xl font-semibold text-stone-900">
+          Recevoir la date d'ouverture en avant-première
+        </h2>
+        <p className="mb-8 text-base leading-relaxed text-stone-500">
+          Abonnez-vous à la newsletter pour recevoir toutes les actualités
+          de la galerie — artistes invitées, coulisses du projet et date
+          d'ouverture en exclusivité.
+        </p>
+        <Link
+          to="/newsletter"
+          className="inline-flex items-center gap-2 rounded-full border border-clay-500 px-6 py-3 text-xs font-bold uppercase tracking-widest text-clay-500 transition-colors hover:bg-clay-500 hover:text-white"
+        >
+          S'abonner à la newsletter →
+        </Link>
+      </section>
+
+      {/* ── LIENS ────────────────────────────────────────────────── */}
+      <section className="mx-auto mb-20 max-w-3xl px-6 lg:px-0">
+        <p className="mb-6 text-center text-sm text-stone-500">
+          En attendant l'ouverture, explorez le podcast et les articles :
+        </p>
+        <div className="flex flex-wrap justify-center gap-3">
+          {[
+            { label: 'Podcasts', href: '/podcasts' },
+            { label: 'Articles', href: '/articles' },
+            { label: 'Mon histoire', href: '/about' },
+          ].map(({ label, href }) => (
+            <Link
+              key={href}
+              to={href}
+              className="rounded-full border border-clay-200 px-5 py-2 text-xs font-semibold uppercase tracking-widest text-stone-600 transition-colors hover:border-clay-500 hover:text-clay-500"
+            >
+              {label}
+            </Link>
+          ))}
+        </div>
+      </section>
+
+    </Layout>
+  );
+}
+
+export const Head = () => (
+  <SEO
+    title="Galerie ART au féminin — Exposition virtuelle immersive 3D"
+    description="Une galerie d'art immersive en 3D dédiée aux femmes artistes. Première exposition : « Sororité », une vingtaine d'artistes autour du thème de la sororité. Bientôt disponible."
+  />
+);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -135,9 +135,12 @@ const IndexPage = ({ data }) => {
               la sororité — ce lien puissant entre femmes qui traverse l'histoire de l'art.
             </p>
             <div className="mt-10 flex flex-wrap items-center gap-5">
-              <span className="inline-flex items-center gap-2 rounded-full border border-clay-500/50 bg-clay-500/10 px-5 py-2.5 text-xs font-bold uppercase tracking-widest text-clay-300">
-                ✦ Exposition virtuelle en préparation
-              </span>
+              <a
+                href="/galerie"
+                className="inline-flex items-center gap-2 rounded-full border border-clay-500/50 bg-clay-500/10 px-5 py-2.5 text-xs font-bold uppercase tracking-widest text-clay-300 transition-colors hover:bg-clay-500/20"
+              >
+                ✦ Découvrir la galerie →
+              </a>
             </div>
           </div>
 

--- a/src/pages/press.tsx
+++ b/src/pages/press.tsx
@@ -5,7 +5,6 @@ import React, { ReactElement } from 'react';
 import Layout from '../components/layout';
 import PressList from '../components/pressList';
 import SEO from '../components/seo';
-import Text from '../components/text';
 
 interface PressPageProps {
   data: {
@@ -15,143 +14,121 @@ interface PressPageProps {
   };
 }
 
-const PressLogoList = () => (
-  <ul className="m-auto flex justify-center py-2">
-    <li>
-      <StaticImage
-        src="../images/logo-panthere-premiere.png"
-        alt="Logo Premier Panthere"
-        placeholder="blurred"
-      />
-    </li>
-    <li>
-      <StaticImage
-        src="../images/logo-podtail.png"
-        alt="Logo Podtail"
-        placeholder="blurred"
-      />
-    </li>
-    <li>
-      <StaticImage
-        src="../images/logo-cultea.png"
-        alt="Logo Cultea"
-        placeholder="blurred"
-      />
-    </li>
-    <li>
-      <StaticImage
-        src="../images/logo-francetv.png"
-        alt="Logo France Info"
-        placeholder="blurred"
-      />
-    </li>
-    <li>
-      <StaticImage
-        src="../images/logo-amylee.png"
-        alt="Logo Amylee"
-        placeholder="blurred"
-      />
-    </li>
-  </ul>
-);
+const mediaLogos = [
+  { src: '../images/logo-panthere-premiere.png', alt: 'Panthère Première' },
+  { src: '../images/logo-podtail.png', alt: 'Podtail' },
+  { src: '../images/logo-cultea.png', alt: 'Cultea' },
+  { src: '../images/logo-francetv.png', alt: 'France Info' },
+  { src: '../images/logo-amylee.png', alt: 'Amylee' },
+];
 
-export default function pressPage({ data }: PressPageProps): ReactElement {
+export default function PressPage({ data }: PressPageProps): ReactElement {
   const press = data.allPrismicPress.nodes;
+
   return (
-    <Layout>
-      <div className="m-auto max-w-2xl">
-        <Text as="h1" variant={'h1'} className="mb-4">
-          Presse
-        </Text>
-        <Text as="p" variant={'p'}>
-          Contact presse : artaufemininlepodcast@gmail.com
-        </Text>
-        <PressLogoList />
-        <PressList allPress={press} />
-      </div>
+    <Layout withInstagram={false}>
 
-      <Text as="h2" variant={'h2'} className="my-8 text-center">
-        Logos
-      </Text>
-      <div className="m-auto text-center">SVG</div>
-      <ul className="m-auto flex justify-center space-x-4 py-12">
-        <li>
-          <StaticImage
-            src="../images/logo/logo-black.svg"
-            alt="Logo Noir ART au féminin"
-            width={200}
-          />
-        </li>
+      {/* En-tête */}
+      <section className="m-auto mb-12 mt-8 w-3/4">
+        <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-clay-500">
+          Médias
+        </p>
+        <h1 className="font-display text-4xl font-semibold leading-tight text-stone-900 md:text-5xl">
+          Espace presse
+        </h1>
+        <p className="mt-4 max-w-xl text-base leading-relaxed text-stone-500">
+          ART au féminin dans les médias. Pour toute demande presse ou partenariat,
+          contactez-nous par email.
+        </p>
+        <a
+          href="mailto:artaufemininlepodcast@gmail.com"
+          className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-clay-500 transition-colors hover:text-clay-700"
+        >
+          artaufemininlepodcast@gmail.com →
+        </a>
+      </section>
 
-        <li>
-          <StaticImage
-            width={200}
-            src="../images/logo/logo-green.svg"
-            alt="Logo Vert ART au féminin"
-          />
-        </li>
+      {/* Logos médias */}
+      <section className="m-auto mb-16 w-3/4">
+        <p className="mb-6 text-xs font-semibold uppercase tracking-widest text-clay-500">
+          Ils en parlent
+        </p>
+        <div className="flex flex-wrap items-center justify-start gap-8 rounded-sm border border-clay-200 bg-cream-50 p-8">
+          <StaticImage src="../images/logo-panthere-premiere.png" alt="Panthère Première" placeholder="blurred" height={40} />
+          <StaticImage src="../images/logo-podtail.png" alt="Podtail" placeholder="blurred" height={40} />
+          <StaticImage src="../images/logo-cultea.png" alt="Cultea" placeholder="blurred" height={40} />
+          <StaticImage src="../images/logo-francetv.png" alt="France Info" placeholder="blurred" height={40} />
+          <StaticImage src="../images/logo-amylee.png" alt="Amylee" placeholder="blurred" height={40} />
+        </div>
+      </section>
 
-        <li>
-          <StaticImage
-            width={200}
-            src="../images/logo/logo-white.svg"
-            alt="Logo Blanc ART au féminin"
-          />
-        </li>
-      </ul>
-      <div className="m-auto text-center">PNG</div>
-      <ul className="m-auto flex justify-center space-x-4 py-12">
-        <li>
-          <StaticImage
-            src="../images/logo/logo-black.png"
-            alt="Logo Noir ART au féminin"
-            width={200}
-          />
-        </li>
+      {/* Articles de presse */}
+      {press.length > 0 && (
+        <section className="m-auto mb-16 w-3/4">
+          <p className="mb-6 text-xs font-semibold uppercase tracking-widest text-clay-500">
+            Articles &amp; mentions
+          </p>
+          <PressList allPress={press} />
+        </section>
+      )}
 
-        <li>
-          <StaticImage
-            width={200}
-            src="../images/logo/logo-green.png"
-            alt="Logo Vert ART au féminin"
-          />
-        </li>
+      {/* Kit presse — logos téléchargeables */}
+      <section className="m-auto mb-20 w-3/4">
+        <p className="mb-6 text-xs font-semibold uppercase tracking-widest text-clay-500">
+          Kit presse — logos
+        </p>
+        <div className="rounded-sm border border-clay-200 bg-cream-50 p-8">
+          <p className="mb-6 text-sm leading-relaxed text-stone-500">
+            Formats SVG et PNG disponibles ci-dessous pour toute utilisation presse.
+          </p>
 
-        <li>
-          <StaticImage
-            width={200}
-            src="../images/logo/logo-white.png"
-            alt="Logo Blanc ART au féminin"
-          />
-        </li>
-      </ul>
+          <div className="mb-8">
+            <p className="mb-4 text-xs font-semibold text-stone-400 uppercase tracking-widest">SVG</p>
+            <div className="flex flex-wrap items-center gap-8">
+              <StaticImage src="../images/logo/logo-black.svg" alt="Logo Noir ART au féminin" width={160} />
+              <div className="rounded-sm bg-stone-800 p-4">
+                <StaticImage src="../images/logo/logo-white.svg" alt="Logo Blanc ART au féminin" width={160} />
+              </div>
+              <div className="rounded-sm bg-sage-500 p-4">
+                <StaticImage src="../images/logo/logo-green.svg" alt="Logo Vert ART au féminin" width={160} />
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <p className="mb-4 text-xs font-semibold text-stone-400 uppercase tracking-widest">PNG</p>
+            <div className="flex flex-wrap items-center gap-8">
+              <StaticImage src="../images/logo/logo-black.png" alt="Logo Noir ART au féminin" width={160} />
+              <div className="rounded-sm bg-stone-800 p-4">
+                <StaticImage src="../images/logo/logo-white.png" alt="Logo Blanc ART au féminin" width={160} />
+              </div>
+              <div className="rounded-sm bg-sage-500 p-4">
+                <StaticImage src="../images/logo/logo-green.png" alt="Logo Vert ART au féminin" width={160} />
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
     </Layout>
   );
 }
 
-export const Head = () => {
-  return (
-    <SEO
-      title="Espace Presse"
-      description="Le podcast nouvelle génération qui nous raconte l'histoire des femmes artistes d'hier et d'aujoud'hui"
-    />
-  );
-};
+export const Head = () => (
+  <SEO
+    title="Espace presse — ART au féminin"
+    description="ART au féminin dans les médias. Kit presse, logos et contact pour toute demande de partenariat ou couverture presse."
+  />
+);
 
 export const pressQuery = graphql`
   query allPress {
     allPrismicPress {
       nodes {
         data {
-          description {
-            text
-          }
-          sitename {
-            text
-          }
-          url {
-            url
-          }
+          description { text }
+          sitename { text }
+          url { url }
         }
       }
     }


### PR DESCRIPTION
## Summary

Audit complet du site — 6 améliorations en un seul passage :

### `/galerie` (nouvelle page)
Landing page dédiée à la galerie immersive 3D — hero sombre avec diagramme orbital à 3 niveaux (8+12+20 points = ~20 artistes), section concept, détails de l'exposition « Sororité » (4 info cards), CTA newsletter, liens de navigation

### `/404` redessinée
Grand "404" décoratif en Cormorant clay-200, titre, 3 boutons retour (Accueil, Podcasts, Articles), citation de consolation

### `/faq` redessinée
Accordéon interactif (useState), même en-tête que les autres pages, première question ouverte par défaut, CTA contact en bas

### `/press` + `pressList.tsx` redessinés
Logos médias en carte crème, articles de presse en rows clay, section kit presse avec logos SVG/PNG sur fonds colorés

### `seo.tsx` — Open Graph complet
Ajout `og:image`, `og:locale`, `og:site_name`, `twitter:card`, `twitter:image` — les liens partagés sur Instagram/WhatsApp auront maintenant un aperçu image

### Navigation
- Header : ajout "Galerie" dans la nav desktop et mobile
- Footer : ajout "Galerie 3D" dans la colonne Contenu
- Homepage : teaser galerie → lien cliquable vers `/galerie`

## Test plan

- [ ] `/galerie` — page visible, CTA newsletter fonctionnel
- [ ] `/404` — taper une URL inexistante
- [ ] `/faq` — accordéon ouvre/ferme les questions
- [ ] `/press` — logos et articles visibles
- [ ] Partager un lien sur WhatsApp → aperçu image présent
- [ ] Nav desktop — "Galerie" visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)