### PR TITLE
Redesign galerie page as squeeze page

### DIFF
--- a/src/pages/galerie.tsx
+++ b/src/pages/galerie.tsx
@@ -5,80 +5,63 @@ import SEO from '../components/seo';
 
 export default function GaleriePage(): ReactElement {
   return (
-    <div className="min-h-screen bg-stone-900">
+    <div className="min-h-screen bg-stone-950 text-white">
 
-      {/* ── LOGO ─────────────────────────────────────────────────── */}
-      <div className="flex justify-center pt-10">
-        <Link
-          to="/"
-          className="font-display text-xl font-semibold tracking-tight text-white/60 transition-colors hover:text-white"
-        >
-          ART <span className="italic font-light">au féminin</span>
-        </Link>
-      </div>
+      {/* ── SQUEEZE PAGE — zéro navigation, objectif unique : l'email ── */}
 
-      {/* ── HERO ─────────────────────────────────────────────────── */}
-      <main className="mx-auto max-w-2xl px-6 py-16 text-center lg:py-24">
-
-        {/* Visuel orbital */}
-        <div className="mb-12 flex justify-center">
-          <div className="relative flex items-center justify-center" style={{ width: 180, height: 180 }}>
-            <div className="absolute size-44 rounded-full border border-white/5" />
-            <div className="absolute size-36 rounded-full border border-white/8" />
-            <div className="absolute size-24 rounded-full border border-clay-500/25" />
-            <div className="relative flex size-14 items-center justify-center rounded-full border border-clay-500/50 bg-stone-800">
-              <span className="font-display text-2xl font-light italic text-clay-300">✦</span>
-            </div>
-            {[0,1,2,3,4,5,6,7].map((i) => {
-              const angle = (i / 8) * 360;
-              const rad = (angle * Math.PI) / 180;
-              const x = Math.cos(rad) * 72;
-              const y = Math.sin(rad) * 72;
-              return (
-                <div key={i} className="absolute size-1.5 rounded-full bg-clay-400/60"
-                  style={{ transform: `translate(${x}px, ${y}px)` }} />
-              );
-            })}
-          </div>
-        </div>
+      <main className="mx-auto max-w-xl px-6 py-20 lg:py-28">
 
         {/* Eyebrow */}
-        <p className="mb-4 text-xs font-semibold uppercase tracking-widest text-clay-400">
-          Bientôt disponible · Première exposition
+        <p className="mb-6 text-center text-xs font-semibold uppercase tracking-widest text-clay-400">
+          Galerie ART au féminin · Exposition « Sororité »
         </p>
 
         {/* Titre principal */}
-        <h1 className="font-display text-5xl font-semibold leading-tight text-white md:text-6xl lg:text-7xl">
-          Galerie{' '}
-          <span className="italic font-light text-clay-300">ART au féminin</span>
+        <h1 className="text-center font-display text-4xl font-semibold leading-tight text-white sm:text-5xl lg:text-6xl">
+          Découvrez les artistes{' '}
+          <span className="italic font-light text-clay-300">avant tout le monde</span>
         </h1>
 
-        {/* Sous-titre exposition */}
-        <p className="mt-4 font-display text-2xl font-light italic text-stone-400 md:text-3xl">
-          « Sororité »
+        {/* Sous-titre */}
+        <p className="mx-auto mt-6 max-w-md text-center text-base leading-relaxed text-stone-400">
+          Je prépare une galerie d'art immersive en 3D autour du thème de la <strong className="text-stone-300 font-medium">Sororité</strong> — une vingtaine de femmes artistes réunies dans un espace numérique unique.
         </p>
 
-        {/* Description courte */}
-        <p className="mx-auto mt-6 max-w-md text-base leading-relaxed text-stone-400">
-          Une galerie d'art immersive en 3D dédiée aux femmes artistes.
-          Une vingtaine d'artistes réunies autour du thème de la sororité.
-        </p>
+        {/* Lead magnet — ce qu'ils reçoivent */}
+        <div className="mt-12 rounded-sm border border-clay-700/50 bg-stone-900 p-8">
 
-        {/* Séparateur */}
-        <div className="mx-auto my-10 w-12 border-t border-clay-700" />
+          <p className="mb-1 text-xs font-bold uppercase tracking-widest text-clay-400">
+            Votre cadeau gratuit
+          </p>
+          <h2 className="font-display text-2xl font-semibold text-white lg:text-3xl">
+            Le catalogue complet{' '}
+            <span className="italic font-light text-clay-300">de l'exposition</span>
+          </h2>
+          <p className="mt-3 text-sm leading-relaxed text-stone-400">
+            En laissant votre email, vous recevez en avant-première le catalogue de l'exposition — toutes les artistes, leur univers, leur œuvre, et ce qui les relie autour du thème de la Sororité.
+          </p>
 
-        {/* Proposition de valeur */}
-        <p className="mx-auto mb-8 max-w-sm text-sm font-semibold leading-relaxed text-stone-300">
-          Laissez votre email pour recevoir la date d'ouverture
-          en avant-première et les coulisses du projet.
-        </p>
+          <ul className="mt-6 space-y-3">
+            {[
+              "Le portrait de chacune des ~20 artistes de l'exposition",
+              "La date d'ouverture de la galerie en avant-première",
+              "Les coulisses de la création de l'exposition 3D",
+              "Un accès VIP dès le jour J — avant le grand public",
+            ].map((item) => (
+              <li key={item} className="flex items-start gap-3 text-sm text-stone-300">
+                <span className="mt-0.5 shrink-0 text-clay-400">✦</span>
+                {item}
+              </li>
+            ))}
+          </ul>
+        </div>
 
-        {/* ── FORMULAIRE ───────────────────────────────────────────── */}
+        {/* Formulaire */}
         <form
           action="https://assets.mailerlite.com/jsonp/334411/forms/96016714913810040/subscribe"
           method="post"
           target="_blank"
-          className="mx-auto max-w-sm"
+          className="mt-8"
         >
           <input type="hidden" name="ml-submit" value="1" />
           <input type="hidden" name="anticsrf" value="true" />
@@ -97,39 +80,21 @@ export default function GaleriePage(): ReactElement {
               type="submit"
               className="w-full rounded-sm bg-clay-500 px-6 py-4 text-xs font-bold uppercase tracking-widest text-white transition-colors hover:bg-clay-700"
             >
-              Je veux être informée en avant-première →
+              Oui, je veux découvrir les artistes en avant-première →
             </button>
           </div>
 
-          <p className="mt-4 text-xs text-stone-600">
-            Pas de spam · Désabonnement à tout moment
+          <p className="mt-4 text-center text-xs text-stone-600">
+            Pas de spam · Désabonnement à tout moment · Par Aldjia Boughias
           </p>
         </form>
 
-        {/* Bénéfices */}
-        <div className="mx-auto mt-12 grid max-w-sm grid-cols-3 gap-4 text-center">
-          {[
-            { value: '~20', label: 'artistes' },
-            { value: '3D', label: 'immersif' },
-            { value: '100%', label: 'gratuit' },
-          ].map(({ value, label }) => (
-            <div key={label}>
-              <p className="font-display text-2xl font-semibold text-clay-300">{value}</p>
-              <p className="mt-1 text-xs uppercase tracking-widest text-stone-500">{label}</p>
-            </div>
-          ))}
-        </div>
-
       </main>
 
-      {/* ── PIED ─────────────────────────────────────────────────── */}
       <footer className="pb-10 text-center">
-        <p className="text-xs text-stone-700">
-          © {new Date().getFullYear()} ART au féminin ·{' '}
-          <Link to="/" className="text-stone-600 transition-colors hover:text-stone-400">
-            Retour au site
-          </Link>
-        </p>
+        <Link to="/" className="text-xs text-stone-700 transition-colors hover:text-stone-500">
+          Revenir au site →
+        </Link>
       </footer>
 
     </div>
@@ -138,7 +103,7 @@ export default function GaleriePage(): ReactElement {
 
 export const Head = () => (
   <SEO
-    title="Galerie ART au féminin — Exposition « Sororité » bientôt disponible"
-    description="Une galerie d'art immersive en 3D dédiée aux femmes artistes. Première exposition : Sororité, ~20 artistes. Inscrivez-vous pour recevoir la date d'ouverture en avant-première."
+    title="Galerie ART au féminin — Découvrez les artistes en avant-première"
+    description="Une galerie d'art immersive en 3D dédiée aux femmes artistes. Première exposition : Sororité, ~20 artistes. Recevez 3 portraits exclusifs d'artistes en vous inscrivant."
   />
 );


### PR DESCRIPTION
## Summary
- Suppression de toute navigation (pas de header, pas de liens footer)
- Lead magnet : catalogue complet de l'exposition avec portraits de chacune des ~20 artistes
- Bullet points des bénéfices : portraits, date d'ouverture, coulisses, accès VIP
- Objectif unique : capture d'email via MailerLite
- Lien de sortie discret "Revenir au site" en bas de page

## Test plan
- [ ] Vérifier que la page s'affiche sans header ni footer du site
- [ ] Tester le formulaire MailerLite
- [ ] Vérifier le lien "Revenir au site" en bas

🤖 Generated with [Claude Code](https://claude.com/claude-code)