### PR TITLE
Fix footer newsletter widget — fetch API + inline confirmation

### DIFF
--- a/src/components/newsletter.tsx
+++ b/src/components/newsletter.tsx
@@ -1,6 +1,28 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useState } from 'react';
 
 export default function Newsletter(): ReactElement {
+  const [email, setEmail] = useState('');
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setStatus('loading');
+    try {
+      const body = new FormData();
+      body.append('fields[email]', email);
+      body.append('ml-submit', '1');
+      body.append('anticsrf', 'true');
+      const res = await fetch(
+        'https://assets.mailerlite.com/jsonp/334411/forms/96016714913810040/subscribe',
+        { method: 'POST', body }
+      );
+      const json = await res.json();
+      setStatus(json.success ? 'success' : 'error');
+    } catch {
+      setStatus('error');
+    }
+  }
+
   return (
     <div>
       <h3 className="text-xs font-bold uppercase tracking-widest text-white/50">
@@ -10,40 +32,39 @@ export default function Newsletter(): ReactElement {
         Recevez les épisodes et articles directement par email.
       </p>
 
-      <form
-        className="mt-6"
-        action="https://assets.mailerlite.com/jsonp/334411/forms/96016714913810040/subscribe"
-        data-code=""
-        method="post"
-        target="_blank"
-      >
-        <input type="hidden" name="ml-submit" value="1" />
-        <input type="hidden" name="anticsrf" value="true" />
-        <label htmlFor="email-address" className="sr-only">
-          Adresse email
-        </label>
-
-        <div className="flex gap-0">
-          <input
-            id="emailAddress"
-            autoComplete="email"
-            required
-            aria-label="email"
-            aria-required="true"
-            type="email"
-            data-inputmask=""
-            name="fields[email]"
-            className="min-w-0 flex-1 rounded-l-full border border-white/30 bg-white/20 px-5 py-3 text-sm text-white placeholder:text-white/60 focus:bg-white/30 focus:outline-none transition-colors"
-            placeholder="votre@email.fr"
-          />
-          <button
-            type="submit"
-            className="rounded-r-full border border-white/20 border-l-0 bg-clay-500 px-5 py-3 text-xs font-bold uppercase tracking-widest text-white transition-colors hover:bg-clay-700"
-          >
-            →
-          </button>
-        </div>
-      </form>
+      {status === 'success' ? (
+        <p className="mt-6 text-sm text-white/80">
+          ✦ Merci ! Vous recevrez le prochain email très bientôt.
+        </p>
+      ) : (
+        <form onSubmit={handleSubmit} className="mt-6">
+          <div className="flex gap-0">
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              autoComplete="email"
+              required
+              aria-required="true"
+              aria-label="Adresse email"
+              placeholder="votre@email.fr"
+              className="min-w-0 flex-1 rounded-l-full border border-white/30 bg-white/20 px-5 py-3 text-sm text-white placeholder:text-white/60 focus:bg-white/30 focus:outline-none transition-colors"
+            />
+            <button
+              type="submit"
+              disabled={status === 'loading'}
+              className="rounded-r-full border border-white/20 border-l-0 bg-clay-500 px-5 py-3 text-xs font-bold uppercase tracking-widest text-white transition-colors hover:bg-clay-700 disabled:opacity-60"
+            >
+              {status === 'loading' ? '…' : '→'}
+            </button>
+          </div>
+          {status === 'error' && (
+            <p className="mt-2 text-xs text-red-300">
+              Une erreur s'est produite. Veuillez réessayer.
+            </p>
+          )}
+        </form>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Même fix appliqué au composant Newsletter du footer
- fetch API au lieu du formulaire natif POST
- Message "✦ Merci !" affiché inline après inscription
- État loading (→ devient …) + gestion d'erreur

## Test plan
- [ ] S'inscrire via le formulaire du footer → message de confirmation s'affiche
- [ ] Vérifier l'email dans MailerLite

🤖 Generated with [Claude Code](https://claude.com/claude-code)