### PR TITLE
fix: disable horizontal scroll on mobile

### DIFF
--- a/src/stylesheets/global.css
+++ b/src/stylesheets/global.css
@@ -5,3 +5,10 @@
 @import "palette.css";
 @import "typography.css";
 @import "article.css";
+
+@layer base {
+  html,
+  body {
+    overflow-x: hidden;
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `overflow-x: hidden` on `html` and `body` to prevent horizontal scrolling on mobile
- The issue was caused by sections with negative margins (`-mx-4`) overflowing the viewport width

🤖 Generated with [Claude Code](https://claude.com/claude-code)