### PR TITLE
feat(a11y): amélioration de l'accessibilité sur toutes les pages

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -5,7 +5,9 @@ export const wrapRootElement = ({ element }) => (
   <AudioProvider>{element}</AudioProvider>
 )
 
-export const onRenderBody = ({ setHeadComponents }) => {
+export const onRenderBody = ({ setHtmlAttributes, setHeadComponents }) => {
+  setHtmlAttributes({ lang: 'fr' });
+
   setHeadComponents([
     <link
       key="gf-preconnect"

--- a/src/components/article-list.tsx
+++ b/src/components/article-list.tsx
@@ -104,9 +104,10 @@ export function ArticleList({ allArticles, isRow }: ArticleListItemProps) {
             action={
               <Link
                 to={`/articles/${article.uid}`}
+                aria-label={`Lire l'article : ${title}`}
                 className="text-xs font-semibold uppercase tracking-widest text-clay-500 transition-colors hover:text-clay-700"
               >
-                Lire l'article →
+                Lire l'article <span aria-hidden="true">→</span>
               </Link>
             }
           />

--- a/src/components/articlesHero.tsx
+++ b/src/components/articlesHero.tsx
@@ -43,7 +43,7 @@ export function ArticlesHero({ allArticles }: ArticlesHeroProps) {
       <div className="mt-12 flex justify-end border-t border-neutral-200 pt-6">
         <a
           href="/articles"
-          className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-neutral-400 transition-colors hover:text-neutral-900"
+          className="text-xs font-semibold uppercase tracking-[0.2em] text-neutral-400 transition-colors hover:text-neutral-900"
         >
           Lire tous les articles →
         </a>

--- a/src/components/book-list.tsx
+++ b/src/components/book-list.tsx
@@ -53,7 +53,7 @@ function BookItem({ book, index }: { book: BookProps; index: number }) {
           {excerpt}
         </p>
         <span className="mt-5 text-xs font-semibold uppercase tracking-widest text-clay-500 transition-colors group-hover:text-clay-700">
-          Lire la chronique →
+          Lire la chronique <span aria-hidden="true">→</span>
         </span>
       </div>
     </Link>

--- a/src/components/content-card.tsx
+++ b/src/components/content-card.tsx
@@ -22,7 +22,7 @@ export function ContentCard({
 }: ContentCardProps) {
   return (
     <article className="group flex flex-col">
-      <Link to={href} className="block overflow-hidden bg-neutral-100">
+      <Link to={href} tabIndex={-1} aria-hidden="true" className="block overflow-hidden bg-neutral-100">
         <div className="aspect-square overflow-hidden">
           <img
             src={imageUrl}
@@ -33,7 +33,7 @@ export function ContentCard({
       </Link>
 
       <div className="mt-3 flex flex-1 flex-col">
-        <p className="text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+        <p className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
           {meta}
         </p>
 

--- a/src/components/featured-card.tsx
+++ b/src/components/featured-card.tsx
@@ -23,7 +23,7 @@ export function FeaturedCard({
   imageRight = false,
 }: FeaturedCardProps) {
   const image = (
-    <Link to={href} className="block overflow-hidden bg-neutral-100">
+    <Link to={href} tabIndex={-1} aria-hidden="true" className="block overflow-hidden bg-neutral-100">
       <img
         src={imageUrl}
         alt={imageAlt}
@@ -39,7 +39,7 @@ export function FeaturedCard({
         imageRight ? 'lg:border-r' : 'lg:border-l'
       }`}
     >
-      <p className="text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+      <p className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
         {label}
       </p>
       <Link to={href}>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -101,79 +101,85 @@ export default function Footer({ siteTitle }: FooterProps) {
         <div className="py-14 lg:grid lg:grid-cols-4 lg:gap-10">
 
           <div>
-            <h3 className="text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-white/30">
+            <h3 id="footer-nav-contenu" className="text-xs font-semibold uppercase tracking-[0.25em] text-white/30">
               Contenu
             </h3>
-            <ul role="list" className="mt-6 space-y-3">
-              {navigation.contenu.map((item) => (
-                <li key={item.name}>
-                  <Link
-                    to={item.href}
-                    className="text-sm font-light text-white/60 transition-colors hover:text-white"
-                  >
-                    {item.name}
-                  </Link>
-                </li>
-              ))}
-            </ul>
+            <nav aria-labelledby="footer-nav-contenu">
+              <ul role="list" className="mt-6 space-y-3">
+                {navigation.contenu.map((item) => (
+                  <li key={item.name}>
+                    <Link
+                      to={item.href}
+                      className="text-sm font-light text-white/60 transition-colors hover:text-white"
+                    >
+                      {item.name}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </nav>
           </div>
 
           <div className="mt-10 lg:mt-0">
-            <h3 className="text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-white/30">
+            <h3 id="footer-nav-podcast" className="text-xs font-semibold uppercase tracking-[0.25em] text-white/30">
               Le podcast
             </h3>
-            <ul role="list" className="mt-6 space-y-3">
-              {navigation.podcast.map((item) => (
-                <li key={item.name}>
-                  {'external' in item && item.external ? (
-                    <a
-                      href={item.href}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-sm font-light text-white/60 transition-colors hover:text-white"
-                    >
-                      {item.name}
-                    </a>
-                  ) : (
-                    <Link
-                      to={item.href}
-                      className="text-sm font-light text-white/60 transition-colors hover:text-white"
-                    >
-                      {item.name}
-                    </Link>
-                  )}
-                </li>
-              ))}
-            </ul>
+            <nav aria-labelledby="footer-nav-podcast">
+              <ul role="list" className="mt-6 space-y-3">
+                {navigation.podcast.map((item) => (
+                  <li key={item.name}>
+                    {'external' in item && item.external ? (
+                      <a
+                        href={item.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-sm font-light text-white/60 transition-colors hover:text-white"
+                      >
+                        {item.name}
+                      </a>
+                    ) : (
+                      <Link
+                        to={item.href}
+                        className="text-sm font-light text-white/60 transition-colors hover:text-white"
+                      >
+                        {item.name}
+                      </Link>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </nav>
           </div>
 
           <div className="mt-10 lg:mt-0">
-            <h3 className="text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-white/30">
+            <h3 id="footer-nav-apropos" className="text-xs font-semibold uppercase tracking-[0.25em] text-white/30">
               À propos
             </h3>
-            <ul role="list" className="mt-6 space-y-3">
-              {navigation.apropos.map((item) => (
-                <li key={item.name}>
-                  {'external' in item && item.external ? (
-                    <a
-                      href={item.href}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-sm font-light text-white/60 transition-colors hover:text-white"
-                    >
-                      {item.name}
-                    </a>
-                  ) : (
-                    <Link
-                      to={item.href}
-                      className="text-sm font-light text-white/60 transition-colors hover:text-white"
-                    >
-                      {item.name}
-                    </Link>
-                  )}
-                </li>
-              ))}
-            </ul>
+            <nav aria-labelledby="footer-nav-apropos">
+              <ul role="list" className="mt-6 space-y-3">
+                {navigation.apropos.map((item) => (
+                  <li key={item.name}>
+                    {'external' in item && item.external ? (
+                      <a
+                        href={item.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-sm font-light text-white/60 transition-colors hover:text-white"
+                      >
+                        {item.name}
+                      </a>
+                    ) : (
+                      <Link
+                        to={item.href}
+                        className="text-sm font-light text-white/60 transition-colors hover:text-white"
+                      >
+                        {item.name}
+                      </Link>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </nav>
           </div>
 
           <div className="mt-10 lg:mt-0">

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -22,6 +22,7 @@ export function Header(): ReactElement {
       <div className="hidden lg:flex items-center justify-between px-12 h-14">
         <Link
           to="/"
+          aria-label="ART AU FÉMININ — Accueil"
           className="font-display text-xl font-light tracking-[0.05em] text-neutral-900 transition-colors hover:text-neutral-500"
         >
           ART AU FÉMININ
@@ -33,7 +34,7 @@ export function Header(): ReactElement {
               <a
                 key={item.name}
                 href={item.href}
-                className="text-[0.65rem] font-normal uppercase tracking-[0.2em] text-neutral-500 transition-colors hover:text-neutral-900"
+                className="text-xs font-normal uppercase tracking-[0.2em] text-neutral-500 transition-colors hover:text-neutral-900"
               >
                 {item.name}
               </a>
@@ -41,7 +42,7 @@ export function Header(): ReactElement {
               <Link
                 key={item.name}
                 to={item.href}
-                className="text-[0.65rem] font-normal uppercase tracking-[0.2em] text-neutral-500 transition-colors hover:text-neutral-900"
+                className="text-xs font-normal uppercase tracking-[0.2em] text-neutral-500 transition-colors hover:text-neutral-900"
                 activeClassName="text-neutral-900"
                 partiallyActive={true}
               >
@@ -56,6 +57,7 @@ export function Header(): ReactElement {
       <div className="flex items-center justify-between px-5 h-14 lg:hidden">
         <Link
           to="/"
+          aria-label="ART AU FÉMININ — Accueil"
           className="font-display text-lg font-light tracking-[0.05em] text-neutral-900"
         >
           ART AU FÉMININ
@@ -86,6 +88,7 @@ export function Header(): ReactElement {
           <div className="flex items-center justify-between mb-10">
             <Link
               to="/"
+              aria-label="ART AU FÉMININ — Accueil"
               className="font-display text-lg font-light text-neutral-900"
               onClick={() => setMobileMenuOpen(false)}
             >
@@ -107,7 +110,7 @@ export function Header(): ReactElement {
                 <a
                   key={item.name}
                   href={item.href}
-                  className="px-2 py-3 text-[0.7rem] font-normal uppercase tracking-[0.2em] text-neutral-500 hover:text-neutral-900 transition-colors"
+                  className="px-2 py-3 text-xs font-normal uppercase tracking-[0.2em] text-neutral-500 hover:text-neutral-900 transition-colors"
                 >
                   {item.name}
                 </a>
@@ -115,7 +118,7 @@ export function Header(): ReactElement {
                 <Link
                   key={item.name}
                   to={item.href}
-                  className="px-2 py-3 text-[0.7rem] font-normal uppercase tracking-[0.2em] text-neutral-500 hover:text-neutral-900 transition-colors"
+                  className="px-2 py-3 text-xs font-normal uppercase tracking-[0.2em] text-neutral-500 hover:text-neutral-900 transition-colors"
                   activeClassName="text-neutral-900"
                   partiallyActive={true}
                   onClick={() => setMobileMenuOpen(false)}
@@ -127,7 +130,7 @@ export function Header(): ReactElement {
           </nav>
 
           <div className="mt-auto pt-16 border-t border-neutral-100">
-            <p className="text-[0.65rem] uppercase tracking-widest text-neutral-300">
+            <p className="text-xs uppercase tracking-widest text-neutral-300">
               Par Aldjia Boughias
             </p>
           </div>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -34,9 +34,10 @@ export function Hero({ allEpisodes }: HeroProps) {
       <div className="mt-12 flex justify-end border-t border-neutral-200 pt-6">
         <a
           href="/podcasts"
-          className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-neutral-400 transition-colors hover:text-neutral-900"
+          aria-label="Écouter tous les épisodes"
+          className="text-xs font-semibold uppercase tracking-[0.2em] text-neutral-400 transition-colors hover:text-neutral-900"
         >
-          Écouter tous les épisodes →
+          Écouter tous les épisodes <span aria-hidden="true">→</span>
         </a>
       </div>
     </div>

--- a/src/components/heroCard.tsx
+++ b/src/components/heroCard.tsx
@@ -20,7 +20,7 @@ export const HeroCard = ({ imageUrl, heroLink, heroTitle, subtitle }: HeroCardPr
       </div>
       <div className="mt-3 space-y-1.5">
         {subtitle && (
-          <p className="text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+          <p className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
             {subtitle}
           </p>
         )}

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -58,8 +58,14 @@ function Layout({
 
   return (
     <div className="bg-white">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[9999] focus:rounded focus:bg-white focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-neutral-900 focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-neutral-900"
+      >
+        Passer au contenu principal
+      </a>
       <Header />
-      <main role="main" className="px-4">
+      <main id="main-content" role="main" className="px-4">
         {children}
       </main>
       {withInstagram && <Instagram />}

--- a/src/components/newsletter.tsx
+++ b/src/components/newsletter.tsx
@@ -53,9 +53,10 @@ export default function Newsletter(): ReactElement {
             <button
               type="submit"
               disabled={status === 'loading'}
+              aria-label={status === 'loading' ? 'Envoi en cours…' : "S'inscrire à la newsletter"}
               className="rounded-r-full border border-white/20 border-l-0 bg-clay-500 px-5 py-3 text-xs font-bold uppercase tracking-widest text-white transition-colors hover:bg-clay-700 disabled:opacity-60"
             >
-              {status === 'loading' ? '…' : '→'}
+              <span aria-hidden="true">{status === 'loading' ? '…' : '→'}</span>
             </button>
           </div>
           {status === 'error' && (

--- a/src/components/player/PlayButton.jsx
+++ b/src/components/player/PlayButton.jsx
@@ -26,11 +26,11 @@ export function PlayButton({ player, size = 'large' }) {
     <button
       type="button"
       className={clsx(
-        'group relative flex shrink-0 items-center justify-center rounded-full bg-slate-700 hover:bg-slate-900 focus:outline-none focus:ring-slate-700',
+        'group relative flex shrink-0 items-center justify-center rounded-full bg-slate-700 hover:bg-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2',
         {
-          large: 'h-18 w-18 focus:ring focus:ring-offset-4',
-          medium: 'h-14 w-14 focus:ring-2 focus:ring-offset-2',
-          small: 'h-10 w-10 focus:ring-2 focus:ring-offset-2',
+          large: 'h-18 w-18 focus-visible:ring-offset-4',
+          medium: 'h-14 w-14',
+          small: 'h-10 w-10',
         }[size],
       )}
       onClick={player.toggle}

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -24,19 +24,19 @@ export default function NotFoundPage(): ReactElement {
         <div className="mt-10 flex flex-wrap justify-center gap-3">
           <Link
             to="/"
-            className="border border-neutral-900 bg-neutral-900 px-6 py-3 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-white transition-colors hover:bg-neutral-700"
+            className="border border-neutral-900 bg-neutral-900 px-6 py-3 text-xs font-semibold uppercase tracking-[0.2em] text-white transition-colors hover:bg-neutral-700"
           >
             Accueil
           </Link>
           <Link
             to="/podcasts"
-            className="border border-neutral-300 px-6 py-3 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-neutral-600 transition-colors hover:border-neutral-900 hover:text-neutral-900"
+            className="border border-neutral-300 px-6 py-3 text-xs font-semibold uppercase tracking-[0.2em] text-neutral-600 transition-colors hover:border-neutral-900 hover:text-neutral-900"
           >
             Les Podcasts
           </Link>
           <Link
             to="/articles"
-            className="border border-neutral-200 px-6 py-3 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-neutral-400 transition-colors hover:border-neutral-500 hover:text-neutral-700"
+            className="border border-neutral-200 px-6 py-3 text-xs font-semibold uppercase tracking-[0.2em] text-neutral-400 transition-colors hover:border-neutral-500 hover:text-neutral-700"
           >
             Les Articles
           </Link>

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -14,7 +14,7 @@ export default function AboutPage() {
         <div className="mx-auto max-w-7xl px-6 py-20 lg:flex lg:items-center lg:gap-20 lg:px-16 lg:py-28">
 
           <div className="flex-1">
-            <p className="mb-3 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+            <p className="mb-3 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
               À Propos
             </p>
             <h1 className="font-display text-5xl font-light leading-tight text-neutral-900 md:text-6xl lg:text-7xl">
@@ -32,7 +32,7 @@ export default function AboutPage() {
             <div className="mt-8 flex flex-wrap gap-4">
               <Link
                 to="/podcasts"
-                className="border border-neutral-300 px-6 py-2.5 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-neutral-700 transition-colors hover:border-neutral-900 hover:text-neutral-900"
+                className="border border-neutral-300 px-6 py-2.5 text-xs font-semibold uppercase tracking-[0.2em] text-neutral-700 transition-colors hover:border-neutral-900 hover:text-neutral-900"
               >
                 Écouter le Podcast
               </Link>
@@ -40,9 +40,10 @@ export default function AboutPage() {
                 href="https://aldjia.dev"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="border border-neutral-200 px-6 py-2.5 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-neutral-400 transition-colors hover:border-neutral-500 hover:text-neutral-700"
+                aria-label="Visiter aldjia.dev (ouvre un nouvel onglet)"
+                className="border border-neutral-200 px-6 py-2.5 text-xs font-semibold uppercase tracking-[0.2em] text-neutral-400 transition-colors hover:border-neutral-500 hover:text-neutral-700"
               >
-                aldjia.dev →
+                aldjia.dev <span aria-hidden="true">→</span>
               </a>
             </div>
           </div>
@@ -66,7 +67,7 @@ export default function AboutPage() {
 
       {/* ── MON HISTOIRE ─────────────────────────────────────────── */}
       <section className="m-auto my-20 w-3/4 max-w-3xl">
-        <p className="mb-4 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+        <p className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
           Mon Histoire
         </p>
         <div className="space-y-6">
@@ -111,7 +112,7 @@ export default function AboutPage() {
               quelles en ont été les conséquences du point de vue des hommes.
             </p>
             <footer className="mt-6">
-              <cite className="text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400 not-italic">
+              <cite className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400 not-italic">
                 — Simone de Beauvoir, Le Deuxième Sexe
               </cite>
             </footer>
@@ -123,7 +124,7 @@ export default function AboutPage() {
       <section className="m-auto my-20 w-3/4">
         <div className="grid grid-cols-1 gap-10 md:grid-cols-2">
           <div>
-            <p className="mb-3 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+            <p className="mb-3 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
               Pourquoi ce Podcast ?
             </p>
             <h2 className="font-display text-3xl font-light leading-snug text-neutral-900 md:text-4xl">
@@ -149,7 +150,7 @@ export default function AboutPage() {
 
       {/* ── CE QUE VOUS TROUVEREZ ────────────────────────────────── */}
       <section className="m-auto mb-20 w-3/4">
-        <p className="mb-6 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+        <p className="mb-6 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
           Sur ART AU FÉMININ
         </p>
         <div className="grid grid-cols-1 gap-px bg-neutral-200 border border-neutral-200 sm:grid-cols-2 lg:grid-cols-4">
@@ -164,7 +165,7 @@ export default function AboutPage() {
               to={href}
               className="group bg-white p-6 transition-colors hover:bg-neutral-50"
             >
-              <p className="mb-2 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors group-hover:text-neutral-700">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors group-hover:text-neutral-700">
                 {label}
               </p>
               <p className="text-sm font-light leading-relaxed text-neutral-500">{desc}</p>
@@ -176,7 +177,7 @@ export default function AboutPage() {
       {/* ── RÉSEAUX SOCIAUX ──────────────────────────────────────── */}
       <section className="-mx-4 border-t border-neutral-200 bg-neutral-50 py-16">
         <div className="mx-auto max-w-3xl px-6 text-center lg:px-0">
-          <p className="mb-2 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
             Suivre ART AU FÉMININ
           </p>
           <h2 className="mb-8 font-display text-3xl font-light text-neutral-900">
@@ -194,7 +195,7 @@ export default function AboutPage() {
                 href={href}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="border border-neutral-300 px-5 py-2.5 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-neutral-600 transition-colors hover:border-neutral-900 hover:text-neutral-900"
+                className="border border-neutral-300 px-5 py-2.5 text-xs font-semibold uppercase tracking-[0.2em] text-neutral-600 transition-colors hover:border-neutral-900 hover:text-neutral-900"
               >
                 {name}
               </a>

--- a/src/pages/articles.tsx
+++ b/src/pages/articles.tsx
@@ -25,7 +25,7 @@ const ArticlesPage = ({ data }: ArticlesPageProps) => {
 
       {/* ── EN-TÊTE ───────────────────────────────────────────────── */}
       <section className="mx-auto mb-10 mt-8 w-11/12 max-w-7xl border-b border-neutral-200 pb-8">
-        <p className="mb-2 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+        <p className="mb-2 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
           Tous les Articles
         </p>
         <h1 className="font-display text-4xl font-light leading-tight text-neutral-900 md:text-5xl">
@@ -42,9 +42,9 @@ const ArticlesPage = ({ data }: ArticlesPageProps) => {
         return (
           <section className="mx-auto mb-16 w-11/12 max-w-7xl">
             <div className="mb-8 flex items-baseline border-b border-neutral-200 pb-4">
-              <span className="text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-900">
+              <h2 className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
                 Dernier Article
-              </span>
+              </h2>
             </div>
             <FeaturedCard
               href={`/articles/${featured.uid}`}
@@ -57,9 +57,10 @@ const ArticlesPage = ({ data }: ArticlesPageProps) => {
               cta={
                 <Link
                   to={`/articles/${featured.uid}`}
-                  className="text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors hover:text-neutral-900"
+                  aria-label={`Lire l'article : ${title}`}
+                  className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors hover:text-neutral-900"
                 >
-                  Lire l'Article →
+                  Lire l'Article <span aria-hidden="true">→</span>
                 </Link>
               }
             />
@@ -71,9 +72,9 @@ const ArticlesPage = ({ data }: ArticlesPageProps) => {
       {rest.length > 0 && (
         <section className="mx-auto mb-20 w-11/12 max-w-7xl">
           <div className="mb-8 flex items-baseline border-b border-neutral-200 pb-4">
-            <span className="text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-900">
+            <h2 className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
               Tous les Articles
-            </span>
+            </h2>
           </div>
           <ArticleList allArticles={rest} />
         </section>

--- a/src/pages/citations.tsx
+++ b/src/pages/citations.tsx
@@ -16,7 +16,7 @@ const QuotationPage = ({
   return (
     <Layout withInstagram={false}>
       <section className="m-auto mb-12 mt-8 w-3/4 border-b border-neutral-200 pb-8">
-        <p className="mb-2 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+        <p className="mb-2 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
           Inspiration
         </p>
         <h1 className="font-display text-4xl font-light leading-tight text-neutral-900 md:text-5xl">

--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -28,9 +28,9 @@ function QuestionItem({ question, defaultOpen = false }: { question: FaqPageProp
         onClick={() => setOpen(!open)}
         aria-expanded={open}
       >
-        <h2 className="font-display text-lg font-light leading-snug text-neutral-900">
+        <span className="font-display text-lg font-light leading-snug text-neutral-900">
           {question.data.question.text}
-        </h2>
+        </span>
         <span
           className="mt-0.5 shrink-0 text-neutral-400 transition-transform duration-200 text-lg"
           style={{ transform: open ? 'rotate(45deg)' : 'rotate(0deg)' }}
@@ -55,7 +55,7 @@ export default function FaqPage({ data }: FaqPageProps): ReactElement {
     <Layout withInstagram={false}>
 
       <section className="m-auto mb-12 mt-8 w-3/4">
-        <p className="mb-2 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+        <p className="mb-2 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
           Aide
         </p>
         <h1 className="font-display text-4xl font-light leading-tight text-neutral-900 md:text-5xl">
@@ -76,7 +76,7 @@ export default function FaqPage({ data }: FaqPageProps): ReactElement {
       <section className="m-auto mb-20 w-3/4">
         <div className="flex flex-col gap-4 border border-neutral-200 p-8 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <p className="mb-1 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+            <p className="mb-1 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
               Vous ne trouvez pas votre réponse ?
             </p>
             <p className="font-display text-xl font-light text-neutral-900">
@@ -85,9 +85,9 @@ export default function FaqPage({ data }: FaqPageProps): ReactElement {
           </div>
           <a
             href="mailto:artaufemininlepodcast@gmail.com"
-            className="inline-block border border-neutral-300 px-5 py-2.5 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-neutral-600 transition-colors hover:border-neutral-900 hover:text-neutral-900"
+            className="inline-block border border-neutral-300 px-5 py-2.5 text-xs font-semibold uppercase tracking-[0.2em] text-neutral-600 transition-colors hover:border-neutral-900 hover:text-neutral-900"
           >
-            Envoyer un Email →
+            Envoyer un Email <span aria-hidden="true">→</span>
           </a>
         </div>
       </section>

--- a/src/pages/galerie.tsx
+++ b/src/pages/galerie.tsx
@@ -38,7 +38,7 @@ export default function GaleriePage(): ReactElement {
 
       <main className="mx-auto max-w-xl px-6 py-20 lg:py-28">
 
-        <p className="mb-6 text-center text-[0.6rem] font-semibold uppercase tracking-[0.3em] text-white/30">
+        <p className="mb-6 text-center text-xs font-semibold uppercase tracking-[0.3em] text-white/30">
           Galerie ART AU FÉMININ · Exposition « Sororité »
         </p>
 
@@ -52,7 +52,7 @@ export default function GaleriePage(): ReactElement {
         </p>
 
         <div className="mt-12 border border-white/10 bg-neutral-900 p-8">
-          <p className="mb-1 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-white/30">
+          <p className="mb-1 text-xs font-semibold uppercase tracking-[0.25em] text-white/30">
             Votre Cadeau Gratuit
           </p>
           <h2 className="font-display text-2xl font-light text-white lg:text-3xl">
@@ -101,7 +101,7 @@ export default function GaleriePage(): ReactElement {
               <button
                 type="submit"
                 disabled={status === 'loading'}
-                className="w-full border border-white/20 bg-white/10 px-6 py-4 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-white/70 transition-colors hover:bg-white/20 hover:text-white disabled:opacity-60"
+                className="w-full border border-white/20 bg-white/10 px-6 py-4 text-xs font-semibold uppercase tracking-[0.2em] text-white/70 transition-colors hover:bg-white/20 hover:text-white disabled:opacity-60"
               >
                 {status === 'loading' ? 'Inscription en cours…' : 'Oui, je veux découvrir les artistes en avant-première →'}
               </button>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -21,7 +21,10 @@ const IndexPage = ({ data }) => {
     <Layout withInstagram={false}>
 
       {/* ── HERO — image plein cadre + strip "Now Open" ─────────── */}
-      <section className="-mx-4">
+      <section className="-mx-4" aria-labelledby="hero-heading">
+        <h1 id="hero-heading" className="sr-only">
+          ART AU FÉMININ — Le podcast sur les femmes artistes et l'Histoire de l'Art
+        </h1>
 
         {/* Image pleine hauteur */}
         <div
@@ -36,7 +39,7 @@ const IndexPage = ({ data }) => {
           {/* Gradient + phrase d'accroche */}
           <div className="absolute inset-0 bg-black/40" />
           <div className="absolute inset-0 flex flex-col items-center justify-center px-6 text-center">
-            <p className="mb-5 text-[0.6rem] font-semibold uppercase tracking-[0.3em] text-white/50">
+            <p className="mb-5 text-xs font-semibold uppercase tracking-[0.3em] text-white/50">
               Art au Féminin
             </p>
             <h2 className="max-w-3xl font-display text-4xl font-light leading-tight text-white lg:text-6xl xl:text-7xl">
@@ -53,21 +56,22 @@ const IndexPage = ({ data }) => {
         {latestEpisode && (
           <div className="border-b border-neutral-200 bg-white">
             <div className="mx-auto flex max-w-7xl items-center gap-6 px-6 py-5 lg:px-16">
-              <span className="shrink-0 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+              <span className="shrink-0 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
                 Dernier Épisode
               </span>
               <span className="hidden h-3 w-px shrink-0 bg-neutral-200 sm:block" />
               <span className="flex-1 truncate font-display text-sm font-light text-neutral-900 lg:text-base">
                 {latestEpisode.title}
               </span>
-              <span className="hidden shrink-0 text-[0.6rem] font-light text-neutral-400 sm:block">
+              <span className="hidden shrink-0 text-xs font-light text-neutral-400 sm:block">
                 Saison {latestEpisode.itunes.season} · Épisode {latestEpisode.itunes.episode}
               </span>
               <Link
                 to={`/podcasts/${latestEpisode.guid}`}
-                className="shrink-0 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors hover:text-neutral-900"
+                aria-label={`Écouter : ${latestEpisode.title}`}
+                className="shrink-0 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors hover:text-neutral-900"
               >
-                Écouter →
+                Écouter <span aria-hidden="true">→</span>
               </Link>
             </div>
           </div>
@@ -75,18 +79,19 @@ const IndexPage = ({ data }) => {
       </section>
 
       {/* ── ÉPISODES ─────────────────────────────────────────────── */}
-      <section className="mx-auto mt-16 w-11/12 max-w-7xl">
+      <section className="mx-auto mt-16 w-11/12 max-w-7xl" aria-labelledby="section-episodes">
 
         {/* En-tête de section */}
         <div className="mb-10 flex items-baseline justify-between border-b border-neutral-200 pb-4">
-          <span className="text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-900">
+          <h2 id="section-episodes" className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
             Épisodes
-          </span>
+          </h2>
           <Link
             to="/podcasts"
-            className="text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors hover:text-neutral-900"
+            aria-label="Voir tous les épisodes"
+            className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors hover:text-neutral-900"
           >
-            Voir Tous →
+            Voir Tous <span aria-hidden="true">→</span>
           </Link>
         </div>
 
@@ -106,9 +111,10 @@ const IndexPage = ({ data }) => {
             cta={
               <Link
                 to={`/podcasts/${allEpisodes[0].guid}`}
-                className="text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors hover:text-neutral-900"
+                aria-label={`Écouter l'épisode : ${allEpisodes[0].title}`}
+                className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors hover:text-neutral-900"
               >
-                Écouter l'Épisode →
+                Écouter l'Épisode <span aria-hidden="true">→</span>
               </Link>
             }
           />
@@ -133,9 +139,10 @@ const IndexPage = ({ data }) => {
                 action={
                   <Link
                     to={`/podcasts/${episode.guid}`}
-                    className="text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors hover:text-neutral-900"
+                    aria-label={`Écouter : ${episode.title}`}
+                    className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors hover:text-neutral-900"
                   >
-                    Écouter →
+                    Écouter <span aria-hidden="true">→</span>
                   </Link>
                 }
               />
@@ -148,17 +155,18 @@ const IndexPage = ({ data }) => {
       <div className="mx-auto my-20 w-11/12 max-w-7xl border-t border-neutral-200" />
 
       {/* ── ARTICLES ─────────────────────────────────────────────── */}
-      <section className="mx-auto w-11/12 max-w-7xl">
+      <section className="mx-auto w-11/12 max-w-7xl" aria-labelledby="section-articles">
 
         <div className="mb-10 flex items-baseline justify-between border-b border-neutral-200 pb-4">
-          <span className="text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-900">
+          <h2 id="section-articles" className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
             Articles
-          </span>
+          </h2>
           <Link
             to="/articles"
-            className="text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors hover:text-neutral-900"
+            aria-label="Voir tous les articles"
+            className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors hover:text-neutral-900"
           >
-            Voir Tous →
+            Voir Tous <span aria-hidden="true">→</span>
           </Link>
         </div>
 
@@ -181,9 +189,10 @@ const IndexPage = ({ data }) => {
               cta={
                 <Link
                   to={`/articles/${art.uid}`}
-                  className="text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors hover:text-neutral-900"
+                  aria-label={`Lire l'article : ${title}`}
+                  className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors hover:text-neutral-900"
                 >
-                  Lire l'Article →
+                  Lire l'Article <span aria-hidden="true">→</span>
                 </Link>
               }
             />
@@ -210,9 +219,10 @@ const IndexPage = ({ data }) => {
                   action={
                     <Link
                       to={`/articles/${article.uid}`}
-                      className="text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors hover:text-neutral-900"
+                      aria-label={`Lire : ${title}`}
+                      className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors hover:text-neutral-900"
                     >
-                      Lire →
+                      Lire <span aria-hidden="true">→</span>
                     </Link>
                   }
                 />
@@ -226,7 +236,7 @@ const IndexPage = ({ data }) => {
       <section className="-mx-4 mt-24 border-t border-neutral-200 bg-neutral-950">
         <div className="mx-auto flex max-w-7xl flex-col gap-10 px-6 py-16 lg:flex-row lg:items-end lg:justify-between lg:px-16 lg:py-20">
           <div className="max-w-lg">
-            <p className="mb-3 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-white/40">
+            <p className="mb-3 text-xs font-semibold uppercase tracking-[0.25em] text-white/40">
               Bientôt Disponible · Première Exposition
             </p>
             <h2 className="font-display text-4xl font-light leading-tight text-white lg:text-5xl">
@@ -243,9 +253,10 @@ const IndexPage = ({ data }) => {
           </div>
           <a
             href="/galerie"
-            className="shrink-0 border border-white/20 px-6 py-3 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-white/50 transition-colors hover:border-white/60 hover:text-white"
+            aria-label="Découvrir la Galerie ART AU FÉMININ"
+            className="shrink-0 border border-white/20 px-6 py-3 text-xs font-semibold uppercase tracking-[0.2em] text-white/50 transition-colors hover:border-white/60 hover:text-white"
           >
-            Découvrir la Galerie →
+            Découvrir la Galerie <span aria-hidden="true">→</span>
           </a>
         </div>
       </section>
@@ -254,7 +265,7 @@ const IndexPage = ({ data }) => {
       <section className="mx-auto my-20 w-11/12 max-w-7xl">
         <div className="flex flex-col gap-6 border-t border-neutral-200 pt-10 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <p className="text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+            <p className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
               Soutenez le Podcast
             </p>
             <p className="mt-2 font-display text-2xl font-light text-neutral-900">
@@ -263,7 +274,7 @@ const IndexPage = ({ data }) => {
           </div>
           <a
             href="https://podcasts.apple.com/fr/podcast/art-au-feminin/id1493131152"
-            className="shrink-0 border border-neutral-300 px-6 py-3 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-neutral-600 transition-colors hover:border-neutral-900 hover:text-neutral-900"
+            className="shrink-0 border border-neutral-300 px-6 py-3 text-xs font-semibold uppercase tracking-[0.2em] text-neutral-600 transition-colors hover:border-neutral-900 hover:text-neutral-900"
           >
             Laisser 5 ★ sur Apple Podcasts
           </a>

--- a/src/pages/links.tsx
+++ b/src/pages/links.tsx
@@ -61,7 +61,7 @@ function LinkRow({ item }: { item: LinkItem }) {
 
 function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
-    <p className="mb-3 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+    <p className="mb-3 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
       {children}
     </p>
   );
@@ -96,7 +96,7 @@ export default function LinksPage(): ReactElement {
         {/* ── GALERIE ──────────────────────────────────────────────── */}
         <div className="mb-8 border border-neutral-900 bg-neutral-900">
           <div className="p-5">
-            <p className="mb-1 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-white/40">
+            <p className="mb-1 text-xs font-semibold uppercase tracking-[0.25em] text-white/40">
               Bientôt · Première Exposition
             </p>
             <p className="font-display text-lg font-light text-white">
@@ -112,7 +112,7 @@ export default function LinksPage(): ReactElement {
             </p>
             <a
               href="/newsletter"
-              className="mt-4 inline-block border border-white/20 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-white/50 transition-colors hover:border-white/50 hover:text-white/80"
+              className="mt-4 inline-block border border-white/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-white/50 transition-colors hover:border-white/50 hover:text-white/80"
             >
               Être informée en avant-première
             </a>

--- a/src/pages/livres.tsx
+++ b/src/pages/livres.tsx
@@ -19,7 +19,7 @@ const BooksPage = ({ data }: BooksPageProps) => {
   return (
     <Layout withInstagram={false}>
       <section className="m-auto mb-10 mt-8 w-3/4 border-b border-neutral-200 pb-8">
-        <p className="mb-2 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+        <p className="mb-2 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
           Bibliothèque
         </p>
         <h1 className="font-display text-4xl font-light leading-tight text-neutral-900 md:text-5xl">

--- a/src/pages/newsletter.tsx
+++ b/src/pages/newsletter.tsx
@@ -33,7 +33,7 @@ export default function NewsletterPage(): ReactElement {
       {/* ── HERO ─────────────────────────────────────────────────── */}
       <section className="-mx-4 border-b border-neutral-200">
         <div className="mx-auto max-w-3xl px-6 py-20 text-center lg:py-28">
-          <p className="mb-4 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+          <p className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
             Newsletter
           </p>
           <h1 className="font-display text-4xl font-light leading-tight text-neutral-900 md:text-5xl lg:text-6xl">
@@ -70,7 +70,7 @@ export default function NewsletterPage(): ReactElement {
               <div>
                 <label
                   htmlFor="email"
-                  className="mb-2 block text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-500"
+                  className="mb-2 block text-xs font-semibold uppercase tracking-[0.25em] text-neutral-500"
                 >
                   Adresse Email
                 </label>
@@ -90,7 +90,7 @@ export default function NewsletterPage(): ReactElement {
               <button
                 type="submit"
                 disabled={status === 'loading'}
-                className="w-full border border-neutral-900 bg-neutral-900 px-6 py-3 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-white transition-colors hover:bg-neutral-700 disabled:opacity-60"
+                className="w-full border border-neutral-900 bg-neutral-900 px-6 py-3 text-xs font-semibold uppercase tracking-[0.2em] text-white transition-colors hover:bg-neutral-700 disabled:opacity-60"
               >
                 {status === 'loading' ? 'Inscription en cours…' : "Je m'abonne →"}
               </button>
@@ -111,7 +111,7 @@ export default function NewsletterPage(): ReactElement {
 
       {/* ── CE QUE VOUS RECEVREZ ─────────────────────────────────── */}
       <section className="mx-auto mb-8 max-w-3xl px-6 lg:px-0">
-        <p className="mb-6 text-center text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+        <p className="mb-6 text-center text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
           Au Programme
         </p>
         <div className="grid grid-cols-1 gap-px bg-neutral-200 border border-neutral-200 sm:grid-cols-2 lg:grid-cols-4">
@@ -122,7 +122,7 @@ export default function NewsletterPage(): ReactElement {
             { label: 'La Galerie 3D', desc: 'Les coulisses et actualités de la Galerie ART AU FÉMININ en avant-première.' },
           ].map(({ label, desc }) => (
             <div key={label} className="bg-white p-6 text-center">
-              <p className="mb-2 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
                 {label}
               </p>
               <p className="text-sm font-light leading-relaxed text-neutral-500">{desc}</p>
@@ -135,7 +135,7 @@ export default function NewsletterPage(): ReactElement {
       <section className="-mx-4 my-16 border-y border-neutral-200 bg-neutral-900 py-16">
         <div className="mx-auto max-w-3xl px-6 lg:flex lg:items-center lg:gap-16 lg:px-0">
           <div>
-            <p className="mb-3 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-white/40">
+            <p className="mb-3 text-xs font-semibold uppercase tracking-[0.25em] text-white/40">
               Bientôt · Première Exposition
             </p>
             <h2 className="font-display text-3xl font-light leading-tight text-white md:text-4xl">
@@ -151,7 +151,7 @@ export default function NewsletterPage(): ReactElement {
               actualités en avant-première.
             </p>
             <div className="mt-6">
-              <span className="inline-block border border-white/20 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-white/40">
+              <span className="inline-block border border-white/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-white/40">
                 En préparation — restez informée
               </span>
             </div>
@@ -168,7 +168,7 @@ export default function NewsletterPage(): ReactElement {
           <p className="mt-2 font-display text-xl font-light italic leading-relaxed text-neutral-600 md:text-2xl">
             Le monde regorge de femmes artistes talentueuses. Il est temps de les connaître.
           </p>
-          <cite className="mt-5 block text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400 not-italic">
+          <cite className="mt-5 block text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400 not-italic">
             — Aldjia Boughias
           </cite>
         </div>
@@ -189,7 +189,7 @@ export default function NewsletterPage(): ReactElement {
             <Link
               key={href}
               to={href}
-              className="border border-neutral-200 px-5 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-neutral-500 transition-colors hover:border-neutral-900 hover:text-neutral-900"
+              className="border border-neutral-200 px-5 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-neutral-500 transition-colors hover:border-neutral-900 hover:text-neutral-900"
             >
               {label}
             </Link>

--- a/src/pages/podcasts.tsx
+++ b/src/pages/podcasts.tsx
@@ -43,7 +43,7 @@ function EpisodeCard({ episode }: { episode: any }) {
       action={
         <div className="flex items-center gap-3">
           <PlayButton player={player} size="small" />
-          <span className="text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+          <span className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
             Écouter
           </span>
         </div>
@@ -62,7 +62,7 @@ const PodcastsPage = ({ data }) => {
 
       {/* ── EN-TÊTE ───────────────────────────────────────────────── */}
       <section className="mx-auto mb-10 mt-8 w-11/12 max-w-7xl border-b border-neutral-200 pb-8">
-        <p className="mb-2 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+        <p className="mb-2 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
           Tous les Épisodes
         </p>
         <h1 className="font-display text-4xl font-light leading-tight text-neutral-900 md:text-5xl">
@@ -74,9 +74,9 @@ const PodcastsPage = ({ data }) => {
       {featured && (
         <section className="mx-auto mb-16 w-11/12 max-w-7xl">
           <div className="mb-8 flex items-baseline justify-between border-b border-neutral-200 pb-4">
-            <span className="text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-900">
+            <h2 className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
               Dernier Épisode
-            </span>
+            </h2>
           </div>
           <FeaturedCard
             href={`/podcasts/${featured.guid}`}
@@ -92,9 +92,10 @@ const PodcastsPage = ({ data }) => {
             cta={
               <Link
                 to={`/podcasts/${featured.guid}`}
-                className="text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors hover:text-neutral-900"
+                aria-label={`Écouter l'épisode : ${featured.title}`}
+                className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors hover:text-neutral-900"
               >
-                Écouter l'Épisode →
+                Écouter l'Épisode <span aria-hidden="true">→</span>
               </Link>
             }
           />
@@ -105,9 +106,9 @@ const PodcastsPage = ({ data }) => {
       {rest.length > 0 && (
         <section className="mx-auto mb-20 w-11/12 max-w-7xl">
           <div className="mb-8 flex items-baseline border-b border-neutral-200 pb-4">
-            <span className="text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-900">
+            <h2 className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
               Tous les Épisodes
-            </span>
+            </h2>
           </div>
           <div className="grid grid-cols-1 gap-10 sm:grid-cols-2 lg:grid-cols-3">
             {rest.map((episode) => (

--- a/src/pages/press.tsx
+++ b/src/pages/press.tsx
@@ -21,7 +21,7 @@ export default function PressPage({ data }: PressPageProps): ReactElement {
     <Layout withInstagram={false}>
 
       <section className="m-auto mb-12 mt-8 w-3/4 border-b border-neutral-200 pb-8">
-        <p className="mb-2 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+        <p className="mb-2 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
           Médias
         </p>
         <h1 className="font-display text-4xl font-light leading-tight text-neutral-900 md:text-5xl">
@@ -40,7 +40,7 @@ export default function PressPage({ data }: PressPageProps): ReactElement {
       </section>
 
       <section className="m-auto mb-16 w-3/4">
-        <p className="mb-6 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+        <p className="mb-6 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
           Ils en Parlent
         </p>
         <div className="flex flex-wrap items-center justify-start gap-8 border border-neutral-200 bg-neutral-50 p-8">
@@ -54,7 +54,7 @@ export default function PressPage({ data }: PressPageProps): ReactElement {
 
       {press.length > 0 && (
         <section className="m-auto mb-16 w-3/4">
-          <p className="mb-6 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+          <p className="mb-6 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
             Articles &amp; Mentions
           </p>
           <PressList allPress={press} />
@@ -62,7 +62,7 @@ export default function PressPage({ data }: PressPageProps): ReactElement {
       )}
 
       <section className="m-auto mb-20 w-3/4">
-        <p className="mb-6 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+        <p className="mb-6 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
           Kit Presse — Logos
         </p>
         <div className="border border-neutral-200 p-8">
@@ -71,7 +71,7 @@ export default function PressPage({ data }: PressPageProps): ReactElement {
           </p>
 
           <div className="mb-8">
-            <p className="mb-4 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">SVG</p>
+            <p className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">SVG</p>
             <div className="flex flex-wrap items-center gap-8">
               <StaticImage src="../images/logo/logo-black.svg" alt="Logo Noir ART AU FÉMININ" width={160} />
               <div className="bg-neutral-900 p-4">
@@ -81,7 +81,7 @@ export default function PressPage({ data }: PressPageProps): ReactElement {
           </div>
 
           <div>
-            <p className="mb-4 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">PNG</p>
+            <p className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">PNG</p>
             <div className="flex flex-wrap items-center gap-8">
               <StaticImage src="../images/logo/logo-black.png" alt="Logo Noir ART AU FÉMININ" width={160} />
               <div className="bg-neutral-900 p-4">

--- a/src/templates/article.tsx
+++ b/src/templates/article.tsx
@@ -95,7 +95,7 @@ export default function Article(props: PropsArticle): ReactElement {
 
           <div className="absolute bottom-0 left-0 right-0 px-6 pb-10 lg:px-0">
             <div className="mx-auto max-w-3xl">
-              <p className="mb-3 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-white/60">
+              <p className="mb-3 text-xs font-semibold uppercase tracking-[0.25em] text-white/60">
                 Article
               </p>
               <h1 className="font-display text-3xl font-light leading-tight text-white md:text-4xl lg:text-5xl">
@@ -111,7 +111,7 @@ export default function Article(props: PropsArticle): ReactElement {
 
         {!imageHero?.url && (
           <header className="py-16">
-            <p className="mb-3 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+            <p className="mb-3 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
               Article
             </p>
             <h1 className="font-display text-4xl font-light leading-tight text-neutral-900 md:text-5xl lg:text-6xl">
@@ -150,7 +150,7 @@ export default function Article(props: PropsArticle): ReactElement {
             />
           </div>
           <div>
-            <p className="mb-1 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+            <p className="mb-1 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
               À propos de l'Autrice
             </p>
             <p className="text-sm font-light leading-relaxed text-neutral-500">
@@ -161,7 +161,7 @@ export default function Article(props: PropsArticle): ReactElement {
 
         {/* Mécénat */}
         <section className="my-10 border border-neutral-200 p-6">
-          <p className="mb-1 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+          <p className="mb-1 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
             Mécénat
           </p>
           <h2 className="mb-3 font-display text-xl font-light text-neutral-900">
@@ -175,7 +175,8 @@ export default function Article(props: PropsArticle): ReactElement {
             href="https://fr.tipeee.com/art-au-feminin"
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-block border border-neutral-300 px-5 py-2.5 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-neutral-600 transition-colors hover:border-neutral-900 hover:text-neutral-900"
+            aria-label="Soutenir ART AU FÉMININ sur Tipeee (ouvre un nouvel onglet)"
+            className="inline-block border border-neutral-300 px-5 py-2.5 text-xs font-semibold uppercase tracking-[0.2em] text-neutral-600 transition-colors hover:border-neutral-900 hover:text-neutral-900"
           >
             Soutenir sur Tipeee
           </a>
@@ -187,7 +188,7 @@ export default function Article(props: PropsArticle): ReactElement {
       {/* ── AUTRES ARTICLES ───────────────────────────────────────── */}
       {(previousUid || nextUid) && (
         <div className="mx-auto mb-20 max-w-3xl px-6 lg:px-0">
-          <p className="mb-6 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+          <p className="mb-6 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
             Autres Articles
           </p>
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">

--- a/src/templates/book.tsx
+++ b/src/templates/book.tsx
@@ -31,7 +31,7 @@ export default function Book(props: BookProps): ReactElement {
       {/* ── EN-TÊTE ──────────────────────────────────────────────── */}
       <div className="border-b border-neutral-200 pb-10 pt-16">
         <div className="mx-auto max-w-3xl px-6 lg:px-0">
-          <p className="mb-3 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+          <p className="mb-3 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
             Chronique
           </p>
           <h1 className="font-display text-4xl font-light leading-tight text-neutral-900 md:text-5xl lg:text-6xl">
@@ -60,7 +60,7 @@ export default function Book(props: BookProps): ReactElement {
             />
           </div>
           <div>
-            <p className="mb-1 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+            <p className="mb-1 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
               À propos de l'Autrice
             </p>
             <p className="text-sm font-light leading-relaxed text-neutral-500">
@@ -71,7 +71,7 @@ export default function Book(props: BookProps): ReactElement {
 
         {/* Mécénat */}
         <section className="my-10 border border-neutral-200 p-6">
-          <p className="mb-1 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+          <p className="mb-1 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
             Mécénat
           </p>
           <h2 className="mb-3 font-display text-xl font-light text-neutral-900">
@@ -85,7 +85,7 @@ export default function Book(props: BookProps): ReactElement {
             href="https://fr.tipeee.com/art-au-feminin"
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-block border border-neutral-300 px-5 py-2.5 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-neutral-600 transition-colors hover:border-neutral-900 hover:text-neutral-900"
+            className="inline-block border border-neutral-300 px-5 py-2.5 text-xs font-semibold uppercase tracking-[0.2em] text-neutral-600 transition-colors hover:border-neutral-900 hover:text-neutral-900"
           >
             Soutenir sur Tipeee
           </a>

--- a/src/templates/episode.tsx
+++ b/src/templates/episode.tsx
@@ -42,7 +42,7 @@ export default function Episode({ pageContext }) {
         <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent" />
         <div className="absolute bottom-0 left-0 right-0 px-6 pb-10 lg:px-0">
           <div className="mx-auto max-w-3xl">
-            <p className="mb-3 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-white/60">
+            <p className="mb-3 text-xs font-semibold uppercase tracking-[0.25em] text-white/60">
               Saison {season} · Épisode {episode}
               {duration && <span> · {duration}</span>}
             </p>
@@ -60,7 +60,7 @@ export default function Episode({ pageContext }) {
         <div className="flex items-center gap-5 border-b border-neutral-200 py-8">
           <PlayButton player={player} size="medium" />
           <div>
-            <p className="text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+            <p className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
               Écouter l'Épisode
             </p>
             {duration && (
@@ -91,7 +91,7 @@ export default function Episode({ pageContext }) {
             />
           </div>
           <div>
-            <p className="mb-1 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+            <p className="mb-1 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
               Présenté par
             </p>
             <p className="text-sm font-light leading-relaxed text-neutral-500">
@@ -102,7 +102,7 @@ export default function Episode({ pageContext }) {
 
         {/* Mécénat */}
         <section className="my-10 border border-neutral-200 p-6">
-          <p className="mb-1 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+          <p className="mb-1 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
             Mécénat
           </p>
           <h2 className="mb-3 font-display text-xl font-light text-neutral-900">
@@ -116,7 +116,8 @@ export default function Episode({ pageContext }) {
             href="https://fr.tipeee.com/art-au-feminin"
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-block border border-neutral-300 px-5 py-2.5 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-neutral-600 transition-colors hover:border-neutral-900 hover:text-neutral-900"
+            aria-label="Soutenir ART AU FÉMININ sur Tipeee (ouvre un nouvel onglet)"
+            className="inline-block border border-neutral-300 px-5 py-2.5 text-xs font-semibold uppercase tracking-[0.2em] text-neutral-600 transition-colors hover:border-neutral-900 hover:text-neutral-900"
           >
             Soutenir sur Tipeee
           </a>
@@ -127,7 +128,7 @@ export default function Episode({ pageContext }) {
 
       {/* ── ÉCOUTER SUR LES PLATEFORMES ──────────────────────────── */}
       <div className="mx-auto mb-20 max-w-3xl px-6 lg:px-0">
-        <p className="mb-6 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-neutral-400">
+        <p className="mb-6 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
           Écouter sur
         </p>
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">


### PR DESCRIPTION
## Résumé

Corrections d'accessibilité WCAG sur l'ensemble du site.

### Structure & sémantique
- Ajout de `lang="fr"` sur `<html>` via `gatsby-ssr.js`
- Skip link "Passer au contenu principal" + `id="main-content"` sur `<main>`
- Hiérarchie de titres corrigée : `<h1>` caché (sr-only) sur la home, labels de sections `<span>` → `<h2>`
- `<h2>` dans le `<button>` FAQ → `<span>` (HTML invalide)

### Navigation & liens
- Doubles liens dans les cards supprimés du tab order (`tabIndex=-1` + `aria-hidden` sur le lien image)
- `aria-label` descriptifs sur tous les liens génériques ("Écouter →", "Lire →", "Voir Tous →")
- Flèches décoractives `→` wrappées dans `<span aria-hidden="true">`
- Liens logo avec `aria-label="ART AU FÉMININ — Accueil"`
- `<nav aria-labelledby>` autour des 3 colonnes de navigation du footer

### Composants interactifs
- Focus visible corrigé sur `PlayButton` (`focus-visible:ring` au lieu de `focus:outline-none`)
- Bouton newsletter avec `aria-label` descriptif

### Lisibilité
- 93 textes trop petits (9.6px–11.2px) remplacés par `text-xs` (12px) sur 22 fichiers

## Plan de test

- [ ] Appuyer sur `Tab` dès le chargement → le skip link doit apparaître
- [ ] Naviguer au clavier sur `/podcasts` → une seule tabulation par card (titre uniquement)
- [ ] Naviguer au clavier sur `/faq` → accordion fonctionnel
- [ ] Lancer axe DevTools sur la home et vérifier la réduction des erreurs
- [ ] VoiceOver (Cmd+F5) → les liens annoncent le titre du contenu

🤖 Generated with [Claude Code](https://claude.com/claude-code)