### PR TITLE
feat(seo): audit SEO complet — structured data, og:image, noindex, www

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,7 +1,7 @@
 const siteConfig = require("./siteConfig")
 
 const { linkResolver } = require("./src/utils/linkResolver.ts")
-const siteUrl = process.env.URL || `https://www.artaufeminin.fr`
+const siteUrl = process.env.URL || siteConfig.siteUrl
 module.exports = {
   siteMetadata: {
     ...siteConfig,
@@ -57,42 +57,15 @@ module.exports = {
               path
             }
           }
-          allPrismicBlogPost {
-            nodes {
-              last_publication_date
-            }
-          }
-          allAnchorEpisode {
-            nodes {
-              pubDate
-            }
-          }
-          allPrismicBookReview {
-            nodes {
-              last_publication_date
-            }
-          }
         }
       `,
         resolveSiteUrl: () => siteUrl,
         resolvePages: ({ allSitePage: { nodes: allPages } }) => {
-          return allPages.map((page) => {
-            return { ...page }
-          })
+          return allPages.map((page) => ({ ...page }))
         },
-        serialize: ({ path, last_publication_date, pubDate }) => {
-          if (path.startsWith("/articles/")) {
-            return {
-              url: `${siteUrl}${path}`,
-              lastmod: last_publication_date,
-            }
-          } else {
-            return {
-              url: `${siteUrl}${path}`,
-              lastmod: pubDate,
-            }
-          }
-        },
+        serialize: ({ path }) => ({
+          url: `${siteUrl}${path}`,
+        }),
       },
     },
     `gatsby-plugin-react-helmet`,

--- a/siteConfig.js
+++ b/siteConfig.js
@@ -4,8 +4,8 @@ module.exports = {
   shortName: "ART",
   description:
     "Explorons l’histoire des femmes artistes d’hier et d’aujourd’hui",
-  url: "https://artaufeminin.fr",
-  siteUrl: "https://artaufeminin.fr",
+  url: "https://www.artaufeminin.fr",
+  siteUrl: "https://www.artaufeminin.fr",
   prefix: "/",
   author: "Aldjia",
   email: "artaufemininlepodcast@gmail.com",

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -8,15 +8,26 @@ export function SeoHead({
   title,
   metaDescription,
   image = OG_IMAGE,
+  imageAlt,
+  url,
+  type = 'website',
+  noindex = false,
+  jsonLd,
 }: {
   title: string;
   metaDescription: string;
   image?: string;
+  imageAlt?: string;
+  url?: string;
+  type?: 'website' | 'article';
+  noindex?: boolean;
+  jsonLd?: object | object[];
 }) {
   return (
     <>
       <title>{title}</title>
       <meta name="description" content={metaDescription} />
+      {noindex && <meta name="robots" content="noindex, follow" />}
       <meta
         name="google-site-verification"
         content="_I5e7rtsxD_MXi3RnD2AsbiQopSHnXHQ_eEAKQYuLPk"
@@ -24,17 +35,26 @@ export function SeoHead({
       {/* Open Graph */}
       <meta property="og:title" content={title} />
       <meta property="og:description" content={metaDescription} />
-      <meta property="og:type" content="website" />
+      <meta property="og:type" content={type} />
       <meta property="og:image" content={image} />
+      <meta property="og:image:alt" content={imageAlt ?? title} />
       <meta property="og:image:width" content="1200" />
       <meta property="og:image:height" content="630" />
       <meta property="og:locale" content="fr_FR" />
       <meta property="og:site_name" content="ART au féminin" />
+      {url && <meta property="og:url" content={url} />}
       {/* Twitter / X */}
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:title" content={title} />
       <meta name="twitter:description" content={metaDescription} />
       <meta name="twitter:image" content={image} />
+      <meta name="twitter:image:alt" content={imageAlt ?? title} />
+      {/* JSON-LD */}
+      {jsonLd && (
+        <script type="application/ld+json">
+          {JSON.stringify(jsonLd)}
+        </script>
+      )}
     </>
   );
 }
@@ -43,10 +63,20 @@ function SEO({
   description,
   title,
   image,
+  imageAlt,
+  url,
+  type,
+  noindex,
+  jsonLd,
 }: {
   description: string;
   title: string;
   image?: string;
+  imageAlt?: string;
+  url?: string;
+  type?: 'website' | 'article';
+  noindex?: boolean;
+  jsonLd?: object | object[];
 }) {
   const { site } = useStaticQuery(graphql`
     query {
@@ -61,7 +91,16 @@ function SEO({
   `);
   const metaDescription = description || site.siteMetadata.description;
   return (
-    <SeoHead title={title} metaDescription={metaDescription} image={image} />
+    <SeoHead
+      title={title}
+      metaDescription={metaDescription}
+      image={image}
+      imageAlt={imageAlt}
+      url={url}
+      type={type}
+      noindex={noindex}
+      jsonLd={jsonLd}
+    />
   );
 }
 

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -57,5 +57,6 @@ export const Head = () => (
   <SEO
     title="Page introuvable — ART AU FÉMININ"
     description="La page que vous cherchez n'existe pas. Découvrez le podcast ART AU FÉMININ et ses contenus sur les femmes artistes."
+    noindex={true}
   />
 );

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -195,6 +195,7 @@ export default function AboutPage() {
                 href={href}
                 target="_blank"
                 rel="noopener noreferrer"
+                aria-label={`Suivre ART AU FÉMININ sur ${name} (ouvre un nouvel onglet)`}
                 className="border border-neutral-300 px-5 py-2.5 text-xs font-semibold uppercase tracking-[0.2em] text-neutral-600 transition-colors hover:border-neutral-900 hover:text-neutral-900"
               >
                 {name}
@@ -208,11 +209,24 @@ export default function AboutPage() {
   );
 }
 
-export const Head = () => {
+export const Head = ({ location }: { location: { pathname: string } }) => {
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: 'Aldjia Boughias',
+    url: 'https://www.artaufeminin.fr/about',
+    jobTitle: 'Développeuse web orientée Art et Culture',
+    description:
+      "Fondatrice du podcast ART AU FÉMININ, développeuse web et exploratrice de l'Histoire de l'Art.",
+    sameAs: ['https://aldjia.dev', 'https://instagram.com/artaufeminin'],
+  };
+
   return (
     <SEO
       title="Aldjia Boughias — Fondatrice du podcast ART AU FÉMININ"
       description="Je suis Aldjia Boughias, développeuse web orientée art et culture et fondatrice du podcast ART AU FÉMININ. Un projet né de ma passion pour l'histoire de l'art et l'envie de rendre visibles les femmes artistes oubliées."
+      url={`https://www.artaufeminin.fr${location.pathname}`}
+      jsonLd={jsonLd}
     />
   );
 };

--- a/src/pages/articles.tsx
+++ b/src/pages/articles.tsx
@@ -95,10 +95,11 @@ export const query = graphql`
   }
 `;
 
-export const Head = () => (
+export const Head = ({ location }: { location: { pathname: string } }) => (
   <SEO
     title="Articles sur les Femmes Artistes — ART AU FÉMININ"
     description="Découvrez l'inspiration et la créativité des femmes artistes sur ART AU FÉMININ. Explorez leurs œuvres exceptionnelles, leurs parcours uniques et leurs contributions inestimables à l'Histoire de l'Art."
+    url={`https://www.artaufeminin.fr${location.pathname}`}
   />
 );
 

--- a/src/pages/citations.tsx
+++ b/src/pages/citations.tsx
@@ -46,13 +46,12 @@ export const query = graphql`
   }
 `;
 
-export const Head = () => {
-  return (
-    <SEO
-      title="Citations de Femmes Artistes — ART AU FÉMININ"
-      description="Des paroles inspirantes qui traversent le temps — ce que les femmes artistes ont dit de l'Art, de la création et de leur vie."
-    />
-  );
-};
+export const Head = ({ location }: { location: { pathname: string } }) => (
+  <SEO
+    title="Citations de Femmes Artistes — ART AU FÉMININ"
+    description="Des paroles inspirantes qui traversent le temps — ce que les femmes artistes ont dit de l'Art, de la création et de leur vie."
+    url={`https://www.artaufeminin.fr${location.pathname}`}
+  />
+);
 
 export default QuotationPage;

--- a/src/pages/design-system.tsx
+++ b/src/pages/design-system.tsx
@@ -441,6 +441,10 @@ export default function DesignSystemPage(): ReactElement {
   );
 }
 
-export const Head = () => {
-  return <SEO title="Design System — ART au féminin" description="Référentiel visuel du site artaufeminin.fr" />;
-};
+export const Head = () => (
+  <SEO
+    title="Design System — ART au féminin"
+    description="Référentiel visuel du site artaufeminin.fr"
+    noindex={true}
+  />
+);

--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -109,9 +109,32 @@ export const pageQuery = graphql`
   }
 `;
 
-export const Head = () => (
-  <SEO
-    title="Questions Fréquentes — ART AU FÉMININ"
-    description="Toutes les réponses à vos questions sur le podcast ART AU FÉMININ — comment écouter, participer, soutenir le projet et en savoir plus sur les femmes artistes."
-  />
-);
+export const Head = ({
+  data,
+  location,
+}: FaqPageProps & { location: { pathname: string } }) => {
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: data.allPrismicFaq.nodes.map((q) => ({
+      '@type': 'Question',
+      name: q.data.question.text,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: q.data.answer.richText
+          .map((block: any) => block.text)
+          .filter(Boolean)
+          .join(' '),
+      },
+    })),
+  };
+
+  return (
+    <SEO
+      title="Questions Fréquentes — ART AU FÉMININ"
+      description="Toutes les réponses à vos questions sur le podcast ART AU FÉMININ — comment écouter, participer, soutenir le projet et en savoir plus sur les femmes artistes."
+      url={`https://www.artaufeminin.fr${location.pathname}`}
+      jsonLd={jsonLd}
+    />
+  );
+};

--- a/src/pages/galerie.tsx
+++ b/src/pages/galerie.tsx
@@ -131,9 +131,11 @@ export default function GaleriePage(): ReactElement {
   );
 }
 
-export const Head = () => (
+export const Head = ({ location }: { location: { pathname: string } }) => (
   <SEO
     title="Galerie ART AU FÉMININ — Découvrez les Artistes en avant-première"
     description="Une galerie d'Art immersive en 3D dédiée aux femmes artistes. Première exposition : Sororité, ~20 artistes. Recevez le catalogue complet en vous inscrivant."
+    url={`https://www.artaufeminin.fr${location.pathname}`}
+    noindex={true}
   />
 );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -337,11 +337,45 @@ export const indexPageQuery = graphql`
   }
 `;
 
-export const Head = () => (
-  <SEO
-    title="ART AU FÉMININ — Le podcast sur les femmes artistes et l'Histoire de l'Art"
-    description="Un podcast présenté par Aldjia Boughias pour redécouvrir les femmes artistes qui ont marqué l'Histoire de l'Art. Épisodes, portraits et articles à écouter et à lire."
-  />
-);
+export const Head = ({ location }: { location: { pathname: string } }) => {
+  const jsonLd = [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Organization',
+      name: 'ART AU FÉMININ',
+      url: 'https://www.artaufeminin.fr',
+      logo: 'https://raw.githubusercontent.com/flexbox/artaufeminin/master/src/images/logo-podcast-art-au-feminin.png',
+      sameAs: [
+        'https://instagram.com/artaufeminin',
+        'https://www.facebook.com/podcastart',
+        'https://podcasts.apple.com/fr/podcast/art-au-feminin/id1493131152',
+        'https://open.spotify.com/show/18f84r0ic2PUenYvBRr2Ps',
+      ],
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'PodcastSeries',
+      name: 'ART AU FÉMININ',
+      description:
+        "Un podcast pour redécouvrir les femmes artistes qui ont façonné l'Art — de l'Antiquité à aujourd'hui.",
+      url: 'https://www.artaufeminin.fr/podcasts',
+      inLanguage: 'fr',
+      author: {
+        '@type': 'Person',
+        name: 'Aldjia Boughias',
+        url: 'https://www.artaufeminin.fr/about',
+      },
+    },
+  ];
+
+  return (
+    <SEO
+      title="ART AU FÉMININ — Le podcast sur les femmes artistes et l'Histoire de l'Art"
+      description="Un podcast présenté par Aldjia Boughias pour redécouvrir les femmes artistes qui ont marqué l'Histoire de l'Art. Épisodes, portraits et articles à écouter et à lire."
+      url={`https://www.artaufeminin.fr${location.pathname}`}
+      jsonLd={jsonLd}
+    />
+  );
+};
 
 export default IndexPage;

--- a/src/pages/links.tsx
+++ b/src/pages/links.tsx
@@ -195,9 +195,10 @@ export default function LinksPage(): ReactElement {
   );
 }
 
-export const Head = () => (
+export const Head = ({ location }: { location: { pathname: string } }) => (
   <SEO
     title="ART AU FÉMININ — Tous les Liens"
     description="Retrouvez ART AU FÉMININ sur Apple Podcasts, Spotify, Deezer, Instagram, et découvrez la future Galerie immersive 3D dédiée aux femmes artistes."
+    url={`https://www.artaufeminin.fr${location.pathname}`}
   />
 );

--- a/src/pages/livres.tsx
+++ b/src/pages/livres.tsx
@@ -49,13 +49,12 @@ export const query = graphql`
   }
 `;
 
-export const Head = () => {
-  return (
-    <SEO
-      title="Livres sur les Femmes Artistes — ART AU FÉMININ"
-      description="Une sélection de chroniques pour explorer l'Histoire des femmes dans l'Art — biographies, essais, monographies."
-    />
-  );
-};
+export const Head = ({ location }: { location: { pathname: string } }) => (
+  <SEO
+    title="Livres sur les Femmes Artistes — ART AU FÉMININ"
+    description="Une sélection de chroniques pour explorer l'Histoire des femmes dans l'Art — biographies, essais, monographies de femmes artistes de l'Antiquité à nos jours."
+    url={`https://www.artaufeminin.fr${location.pathname}`}
+  />
+);
 
 export default BooksPage;

--- a/src/pages/newsletter.tsx
+++ b/src/pages/newsletter.tsx
@@ -201,9 +201,10 @@ export default function NewsletterPage(): ReactElement {
   );
 }
 
-export const Head = () => (
+export const Head = ({ location }: { location: { pathname: string } }) => (
   <SEO
     title="Newsletter — ART AU FÉMININ, le podcast sur les femmes artistes"
     description="Abonnez-vous à la newsletter d'ART AU FÉMININ et recevez les nouveaux épisodes, articles et chroniques de livres sur les femmes artistes directement dans votre boîte mail."
+    url={`https://www.artaufeminin.fr${location.pathname}`}
   />
 );

--- a/src/pages/podcasts.tsx
+++ b/src/pages/podcasts.tsx
@@ -122,10 +122,11 @@ const PodcastsPage = ({ data }) => {
   );
 };
 
-export const Head = () => (
+export const Head = ({ location }: { location: { pathname: string } }) => (
   <SEO
     title="Tous les Épisodes — ART AU FÉMININ, le podcast sur les femmes artistes"
     description="Écoutez tous les épisodes du podcast ART AU FÉMININ, présenté par Aldjia Boughias. Des récits captivants sur les femmes artistes qui ont marqué l'Histoire de l'Art."
+    url={`https://www.artaufeminin.fr${location.pathname}`}
   />
 );
 

--- a/src/pages/press.tsx
+++ b/src/pages/press.tsx
@@ -96,10 +96,11 @@ export default function PressPage({ data }: PressPageProps): ReactElement {
   );
 }
 
-export const Head = () => (
+export const Head = ({ location }: { location: { pathname: string } }) => (
   <SEO
     title="Espace Presse — ART AU FÉMININ"
     description="ART AU FÉMININ dans les médias. Kit presse, logos et contact pour toute demande de partenariat ou couverture presse."
+    url={`https://www.artaufeminin.fr${location.pathname}`}
   />
 );
 

--- a/src/pages/start.tsx
+++ b/src/pages/start.tsx
@@ -22,6 +22,11 @@ export default function StartPage({}: Props): ReactElement {
   );
 }
 
-export const Head = () => {
-  return <SEO title="Présentez vous" />;
-};
+export const Head = ({ location }: { location: { pathname: string } }) => (
+  <SEO
+    title="Présentez-vous — ART AU FÉMININ"
+    description="Remplissez ce formulaire pour vous présenter à la communauté ART AU FÉMININ."
+    url={`https://www.artaufeminin.fr${location.pathname}`}
+    noindex={true}
+  />
+);

--- a/src/templates/article.tsx
+++ b/src/templates/article.tsx
@@ -206,13 +206,53 @@ export default function Article(props: PropsArticle): ReactElement {
   );
 }
 
-export const Head = (props: PropsArticle) => {
+export const Head = (
+  props: PropsArticle & { location: { pathname: string } }
+) => {
   const { text: seoTitle } = props.pageContext.node.data.title;
   const { text: seoDescription } = props.pageContext.node.data.description;
+  const image = props.pageContext.node.data.image;
+  const seoImage = image?.url;
+  const seoImageAlt = image?.alt || seoTitle;
+  const datePublished = props.pageContext.node.data.date;
+  const canonicalUrl = `https://www.artaufeminin.fr${props.location.pathname}`;
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: seoTitle,
+    description: seoDescription,
+    image:
+      seoImage ||
+      'https://raw.githubusercontent.com/flexbox/artaufeminin/master/src/images/logo-podcast-art-au-feminin.png',
+    url: canonicalUrl,
+    ...(datePublished && { datePublished }),
+    inLanguage: 'fr',
+    author: {
+      '@type': 'Person',
+      name: 'Aldjia Boughias',
+      url: 'https://www.artaufeminin.fr/about',
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: 'ART AU FÉMININ',
+      url: 'https://www.artaufeminin.fr',
+      logo: {
+        '@type': 'ImageObject',
+        url: 'https://raw.githubusercontent.com/flexbox/artaufeminin/master/src/images/logo-podcast-art-au-feminin.png',
+      },
+    },
+  };
+
   return (
     <SEO
       title={`${seoTitle} — ART AU FÉMININ`}
       description={seoDescription}
+      image={seoImage}
+      imageAlt={seoImageAlt}
+      url={canonicalUrl}
+      type="article"
+      jsonLd={jsonLd}
     />
   );
 };

--- a/src/templates/book.tsx
+++ b/src/templates/book.tsx
@@ -85,6 +85,7 @@ export default function Book(props: BookProps): ReactElement {
             href="https://fr.tipeee.com/art-au-feminin"
             target="_blank"
             rel="noopener noreferrer"
+            aria-label="Soutenir ART AU FÉMININ sur Tipeee (ouvre un nouvel onglet)"
             className="inline-block border border-neutral-300 px-5 py-2.5 text-xs font-semibold uppercase tracking-[0.2em] text-neutral-600 transition-colors hover:border-neutral-900 hover:text-neutral-900"
           >
             Soutenir sur Tipeee
@@ -97,13 +98,38 @@ export default function Book(props: BookProps): ReactElement {
   );
 }
 
-export const Head = (props: BookProps) => {
+export const Head = (
+  props: BookProps & { location: { pathname: string } }
+) => {
   const { text: seoTitle } = props.pageContext.node.data.title;
   const { text: seoDescription } = props.pageContext.node.data.content;
+  const canonicalUrl = `https://www.artaufeminin.fr${props.location.pathname}`;
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: seoTitle,
+    description: seoDescription.substring(0, 155),
+    url: canonicalUrl,
+    inLanguage: 'fr',
+    author: {
+      '@type': 'Person',
+      name: 'Aldjia Boughias',
+      url: 'https://www.artaufeminin.fr/about',
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: 'ART AU FÉMININ',
+      url: 'https://www.artaufeminin.fr',
+    },
+  };
+
   return (
     <SEO
       title={`${seoTitle} — ART AU FÉMININ`}
       description={seoDescription.substring(0, 155)}
+      url={canonicalUrl}
+      jsonLd={jsonLd}
     />
   );
 };

--- a/src/templates/episode.tsx
+++ b/src/templates/episode.tsx
@@ -155,10 +155,48 @@ export default function Episode({ pageContext }) {
   );
 }
 
-export const Head = ({ pageContext }) => {
+export const Head = ({
+  pageContext,
+  location,
+}: {
+  pageContext: any;
+  location: { pathname: string };
+}) => {
   const title = pageContext.title;
+  const episodeImage = pageContext.itunes?.image;
   const description = pageContext.itunes?.summary
     ? stripHtml(pageContext.itunes.summary).substring(0, 155)
     : title;
-  return <SEO title={`${title} — ART AU FÉMININ`} description={description} />;
+  const canonicalUrl = `https://www.artaufeminin.fr${location.pathname}`;
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'PodcastEpisode',
+    name: title,
+    description,
+    url: canonicalUrl,
+    ...(episodeImage && { image: episodeImage }),
+    inLanguage: 'fr',
+    partOfSeries: {
+      '@type': 'PodcastSeries',
+      name: 'ART AU FÉMININ',
+      url: 'https://www.artaufeminin.fr/podcasts',
+    },
+    author: {
+      '@type': 'Person',
+      name: 'Aldjia Boughias',
+      url: 'https://www.artaufeminin.fr/about',
+    },
+  };
+
+  return (
+    <SEO
+      title={`${title} — ART AU FÉMININ`}
+      description={description}
+      image={episodeImage}
+      imageAlt={title}
+      url={canonicalUrl}
+      jsonLd={jsonLd}
+    />
+  );
 };

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Disallow:
 
-Sitemap: https://artaufeminin.fr/sitemap-0.xml
+Sitemap: https://www.artaufeminin.fr/sitemap-0.xml


### PR DESCRIPTION
## Résumé

Corrections issues de l'audit SEO complet du site.

- **Composant `seo.tsx`** — nouveaux props `noindex`, `type`, `url`, `imageAlt`, `jsonLd` pour du JSON-LD (structured data)
- **Uniformisation www** — `siteConfig.js`, `robots.txt` et `gatsby-config.js` alignés sur `https://www.artaufeminin.fr`
- **Sitemap** — bug `lastmod` supprimé (les dates n'étaient pas transmises au serializer)
- **`noindex`** ajouté sur `/start`, `/design-system`, `/404`, `/galerie`
- **`og:url`** ajouté sur toutes les pages statiques (via prop `location.pathname`)
- **`og:image` dynamique** dans les templates article et épisode (image propre à chaque contenu)
- **`og:type="article"`** sur les pages articles
- **JSON-LD structured data** sur toutes les pages clés :
  - `/` → `Organization` + `PodcastSeries`
  - `/about` → `Person`
  - `/faq` → `FAQPage` (rich results Google — les Q/R apparaissent directement dans les SERP)
  - `article.tsx` → `BlogPosting`
  - `episode.tsx` → `PodcastEpisode`
  - `book.tsx` → `Article`
- **Accessibilité** — `aria-label` manquants corrigés sur les liens réseaux sociaux (`about.tsx`) et le lien Tipeee (`book.tsx`)

## Plan de test

- [ ] Vérifier le rendu des balises `<head>` sur une page article (og:image, og:type, JSON-LD)
- [ ] Vérifier le rendu sur une page épisode (og:image de l'épisode)
- [ ] Tester le schema FAQPage sur `/faq` avec [Rich Results Test](https://search.google.com/test/rich-results)
- [ ] Vérifier `noindex` présent sur `/start`, `/design-system`, `/404`, `/galerie`
- [ ] Vérifier la cohérence www dans le sitemap généré

🤖 Generated with [Claude Code](https://claude.com/claude-code)