### PR TITLE
fix: corrige la navbar sticky cassée par overflow-x: hidden

### DIFF
--- a/src/stylesheets/global.css
+++ b/src/stylesheets/global.css
@@ -9,6 +9,6 @@
 @layer base {
   html,
   body {
-    overflow-x: hidden;
+    overflow-x: clip;
   }
 }


### PR DESCRIPTION
## Problème

La navbar ne suivait pas au scroll malgré `sticky top-0` sur le `<header>`.

## Cause

Le fix anti-scroll horizontal (`overflow-x: hidden` sur `html` et `body` dans `global.css`) créait un **scroll container**. Or `position: sticky` fonctionne uniquement par rapport au scroll container le plus proche — si ce scroll container est `body`, l'élément sticky ne colle plus au viewport.

## Correction

`overflow-x: hidden` → `overflow-x: clip`

`clip` coupe visuellement le contenu qui déborde **sans créer de scroll container**, ce qui préserve le comportement sticky. Le scroll horizontal reste bien désactivé sur mobile.

## Test plan

- [ ] Vérifier que la navbar reste collée en haut au scroll sur desktop
- [ ] Vérifier que la navbar reste collée en haut au scroll sur mobile
- [ ] Vérifier qu'il n'y a toujours pas de scroll horizontal sur mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)