### PR TITLE
fix: répare le sticky navbar — supprimer overflow-x de html

### DIFF
--- a/src/stylesheets/global.css
+++ b/src/stylesheets/global.css
@@ -7,8 +7,7 @@
 @import "article.css";
 
 @layer base {
-  html,
   body {
-    overflow-x: clip;
+    overflow-x: hidden;
   }
 }


### PR DESCRIPTION
## Problème

La navbar ne suivait toujours pas après le fix précédent (`overflow-x: clip`).

## Cause racine

`overflow-x: clip` (comme `hidden`) sur l'élément **`html`** fait de `html` lui-même le conteneur de scroll du viewport. Les éléments `position: sticky` à l'intérieur sont alors sticky par rapport à ce conteneur, ce qui fait qu'ils ne "collent" plus au défilement.

## Correction

Supprimer `overflow-x` de `html` entièrement. Le garder uniquement sur `body` :

```css
/* avant */
html, body { overflow-x: clip; }

/* après */
body { overflow-x: hidden; }
```

Quand seul `body` a `overflow-x: hidden`, `html` reste le scroll container du viewport. Les éléments sticky sont mesurés par rapport à `html`, donc ils fonctionnent correctement.

## Test plan

- [ ] Vérifier que la navbar colle en haut sur desktop au scroll
- [ ] Vérifier que la navbar colle en haut sur mobile au scroll
- [ ] Vérifier qu'il n'y a toujours pas de scroll horizontal sur mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)