### PR TITLE
feat(quiz+transcript): quiz été 2026 + pipeline transcription SEO

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -71,7 +71,7 @@ module.exports = {
     `gatsby-plugin-react-helmet`,
     `gatsby-plugin-image`,
     {
-      resolve: "gatsby-source-anchor",
+      resolve: require.resolve(`./plugins/gatsby-source-anchor-transcript`),
       options: {
         rss: siteConfig.anchorRssUrl,
       },

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -2,6 +2,68 @@
 // https://www.gatsbyjs.com/docs/reference/config-files/gatsby-node/
 
 const path = require(`path`)
+const https = require(`https`)
+const http = require(`http`)
+
+// Fetch a URL and return the body as a string
+function fetchUrl(url) {
+  return new Promise((resolve, reject) => {
+    const client = url.startsWith('https') ? https : http
+    client.get(url, (res) => {
+      let data = ''
+      res.on('data', (chunk) => { data += chunk })
+      res.on('end', () => resolve({ body: data, contentType: res.headers['content-type'] || '' }))
+    }).on('error', reject)
+  })
+}
+
+// Parse SRT or VTT subtitles → plain text
+function parseSrtOrVtt(text) {
+  return text
+    .split('\n')
+    .filter((line) => {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed === 'WEBVTT') return false
+      if (/^\d+$/.test(trimmed)) return false                          // SRT sequence numbers
+      if (/-->/i.test(trimmed)) return false                          // timestamp lines
+      return true
+    })
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+// Parse Spotify/Apple JSON transcript → plain text
+function parseJsonTranscript(json) {
+  try {
+    const data = JSON.parse(json)
+    // Spotify format: { segments: [{ body: "..." }] }
+    if (Array.isArray(data.segments)) {
+      return data.segments.map((s) => s.body || s.text || '').join(' ').trim()
+    }
+    // Generic array fallback
+    if (Array.isArray(data)) {
+      return data.map((s) => s.body || s.text || s.content || '').join(' ').trim()
+    }
+    return ''
+  } catch {
+    return ''
+  }
+}
+
+async function fetchTranscriptText(url) {
+  try {
+    const { body, contentType } = await fetchUrl(url)
+    if (contentType.includes('json') || url.endsWith('.json')) {
+      return parseJsonTranscript(body)
+    }
+    // SRT or VTT
+    return parseSrtOrVtt(body)
+  } catch {
+    return null
+  }
+}
+
 // Log out information after a build is done
 exports.onPostBuild = ({ reporter }) => {
   reporter.info(`✅ Your Gatsby site has been built`)
@@ -64,6 +126,7 @@ exports.createPages = async ({ graphql, actions }) => {
           contentSnippet
           link
           title
+          transcriptUrl
           itunes {
             summary
             image
@@ -78,7 +141,7 @@ exports.createPages = async ({ graphql, actions }) => {
       }
     }
   `)
-  podcats.data.allAnchorEpisode.nodes.forEach((node) => {
+  for (const node of podcats.data.allAnchorEpisode.nodes) {
     // Redirect old url to new url needs to be before `createPage`
     createRedirect({
       fromPath: `/podcast/${node.guid}`,
@@ -86,14 +149,26 @@ exports.createPages = async ({ graphql, actions }) => {
       isPermanent: true,
     })
 
+    // Fetch transcript content at build time so Google can index it
+    let transcriptText = null
+    if (node.transcriptUrl) {
+      transcriptText = await fetchTranscriptText(node.transcriptUrl)
+      if (transcriptText) {
+        console.info(`  ✅ Transcript fetched for: ${node.title}`)
+      } else {
+        console.warn(`  ⚠️  Could not parse transcript for: ${node.title}`)
+      }
+    }
+
     createPage({
       path: `podcasts/${node.guid}`,
       component: episodeTemplate,
       context: {
         ...node,
+        transcriptText,
       },
     })
-  })
+  }
 
   const articleTemplate = path.resolve(`src/templates/article.tsx`)
   const articles = await graphql(`

--- a/plugins/gatsby-source-anchor-transcript/gatsby-node.js
+++ b/plugins/gatsby-source-anchor-transcript/gatsby-node.js
@@ -1,0 +1,70 @@
+'use strict'
+
+const Parser = require('rss-parser')
+
+exports.sourceNodes = async (
+  { actions, createContentDigest },
+  configOptions
+) => {
+  const { createNode } = actions
+  const { rss } = configOptions
+
+  if (typeof rss !== 'string' || !rss.startsWith('http')) {
+    throw new Error('[gatsby-source-anchor-transcript] rss must be a valid URL')
+  }
+
+  console.time('\nAnchor podcast fetched in')
+
+  // Parse podcast:transcript custom field from the RSS
+  const parser = new Parser({
+    customFields: {
+      item: [
+        ['podcast:transcript', 'transcript'],
+        ['psc:chapters', 'chapters'],
+      ],
+    },
+  })
+
+  const feed = await parser.parseURL(rss)
+
+  if (!feed || !feed.title) {
+    throw new Error(
+      '[gatsby-source-anchor-transcript] Could not fetch data from RSS feed'
+    )
+  }
+
+  const getEpisodeId = (guid) => `anchor-episode-${guid}`
+
+  for (const item of feed.items) {
+    // Normalize transcript field — rss-parser returns either a string (url)
+    // or an object with $ attributes depending on the XML structure
+    let transcriptUrl = null
+    if (item.transcript) {
+      if (typeof item.transcript === 'string') {
+        transcriptUrl = item.transcript
+      } else if (item.transcript.$ && item.transcript.$.url) {
+        transcriptUrl = item.transcript.$.url
+      }
+    }
+
+    const node = {
+      ...item,
+      transcriptUrl,
+      // Remove raw transcript field — we expose transcriptUrl instead
+      transcript: undefined,
+      id: getEpisodeId(item.guid),
+      parent: null,
+      children: [],
+      internal: {
+        type: 'AnchorEpisode',
+        mediaType: 'text/html',
+        content: JSON.stringify(item),
+        contentDigest: createContentDigest(JSON.stringify(item)),
+      },
+    }
+
+    createNode(node)
+  }
+
+  console.timeEnd('\nAnchor podcast fetched in')
+}

--- a/plugins/gatsby-source-anchor-transcript/package.json
+++ b/plugins/gatsby-source-anchor-transcript/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "gatsby-source-anchor-transcript",
+  "version": "1.0.0",
+  "description": "Local Gatsby plugin — extends gatsby-source-anchor with podcast:transcript support",
+  "main": "gatsby-node.js",
+  "dependencies": {
+    "rss-parser": "^3.13.0"
+  }
+}

--- a/src/pages/quiz-ete-2026.tsx
+++ b/src/pages/quiz-ete-2026.tsx
@@ -1,0 +1,255 @@
+import { Link } from 'gatsby';
+import React, { useState } from 'react';
+
+import Layout from '../components/layout';
+import SEO from '../components/seo';
+
+const questions = [
+  {
+    question: "Qui a créé la sculpture géante "Maman", représentant une araignée ?",
+    options: ["Yayoi Kusama", "Louise Bourgeois", "Camille Claudel"],
+    answer: 1,
+    explanation:
+      "Louise Bourgeois a créé "Maman" en 1999 pour l'inauguration de la Tate Modern à Londres. L'araignée représente sa mère, restauratrice de tapisseries — patiente, habile et indispensable comme une araignée.",
+  },
+  {
+    question: "En quelle année les Guerrilla Girls ont-elles été fondées ?",
+    options: ["1975", "1980", "1985"],
+    answer: 2,
+    explanation:
+      "Les Guerrilla Girls naissent en 1985 en réaction à une exposition du MoMA de New York qui ne comptait que 13 femmes sur 169 artistes sélectionnés.",
+  },
+  {
+    question: "Quel est le vrai nom de VALIE EXPORT ?",
+    options: ["Waltraud Hollinger", "Maria Braun", "Ingrid Weber"],
+    answer: 0,
+    explanation:
+      "Née Waltraud Hollinger en 1940 à Linz, elle se rebaptise VALIE EXPORT en 1967 — un nom toujours écrit en majuscules, emprunté à une marque de cigarettes pour dénoncer la marchandisation des femmes.",
+  },
+  {
+    question:
+      "Hilma af Klint a peint ses premières œuvres abstraites en 1906 — combien d'années avant Kandinsky ?",
+    options: ["1 an", "5 ans", "10 ans"],
+    answer: 1,
+    explanation:
+      "Kandinsky est souvent cité comme le père de l'abstraction avec ses premières aquarelles abstraites vers 1911. Hilma af Klint peignait ses "Peintures pour le Temple" dès 1906 — cinq ans avant lui.",
+  },
+  {
+    question:
+      "Berthe Morisot était la seule femme à exposer régulièrement avec quel groupe ?",
+    options: ["Les Cubistes", "Les Fauves", "Les Impressionnistes"],
+    answer: 2,
+    explanation:
+      "Berthe Morisot a participé à sept des huit expositions impressionnistes entre 1874 et 1886. Elle était la seule femme à exposer régulièrement aux côtés de Monet, Renoir et Degas.",
+  },
+  {
+    question:
+      "Quelle œuvre d'Edmonia Lewis a été utilisée comme décoration dans un hippodrome avant d'être retrouvée et restaurée ?",
+    options: ["Hagar in the Wilderness", "Portrait of Lincoln", "The Death of Cleopatra"],
+    answer: 2,
+    explanation:
+      ""The Death of Cleopatra" (1876) a disparu après l'Exposition universelle de Philadelphie. Elle a servi de décoration dans un hippodrome du Illinois avant d'être retrouvée et restaurée. Elle est aujourd'hui conservée au Smithsonian American Art Museum de Washington.",
+  },
+  {
+    question: "Pourquoi Frida Kahlo réalisait-elle autant d'autoportraits ?",
+    options: [
+      ""Parce que les galeries l'exigeaient"",
+      ""Parce que je manque de modèles"",
+      ""Parce que je suis souvent seule et suis le sujet que je connais le mieux"",
+    ],
+    answer: 2,
+    explanation:
+      "Frida Kahlo a réalisé 55 autoportraits sur 143 œuvres au total. Cette phrase, extraite de ses écrits, dit tout de sa démarche : se peindre soi-même comme acte de connaissance, non de narcissisme.",
+  },
+  {
+    question:
+      "Yayoi Kusama est l'artiste vivante la plus cotée au monde. Où vit-elle volontairement depuis des décennies ?",
+    options: [
+      "Dans un monastère à Kyoto",
+      "Dans un hôpital psychiatrique à Tokyo",
+      "Dans une île isolée au Japon",
+    ],
+    answer: 1,
+    explanation:
+      "Depuis 1977, Yayoi Kusama vit volontairement dans un hôpital psychiatrique de Tokyo. Elle y trouve la structure dont elle a besoin pour canaliser ses hallucinations visuelles — et continue de créer chaque jour dans son atelier voisin.",
+  },
+  {
+    question:
+      "Artemisia Gentileschi a été la première femme admise dans quelle institution artistique prestigieuse ?",
+    options: [
+      "L'Académie royale de Londres",
+      "L'École des Beaux-Arts de Paris",
+      "L'Académie des Arts du Dessin de Florence",
+    ],
+    answer: 2,
+    explanation:
+      "En 1616, Artemisia Gentileschi devient la première femme admise à l'Accademia delle Arti del Disegno de Florence — l'une des institutions artistiques les plus influentes de la Renaissance italienne.",
+  },
+  {
+    question:
+      "Käthe Kollwitz pratiquait principalement quel type d'art pour dénoncer la guerre et la misère ?",
+    options: [
+      "La peinture à l'huile abstraite",
+      "La photographie documentaire",
+      "La gravure et le dessin engagés",
+    ],
+    answer: 2,
+    explanation:
+      "Käthe Kollwitz a consacré sa vie à la gravure et au dessin pour représenter la souffrance ouvrière, la guerre et le deuil. Elle a perdu son fils pendant la Première Guerre mondiale et son petit-fils pendant la Seconde.",
+  },
+];
+
+export default function QuizEte2026() {
+  const [answers, setAnswers] = useState<Record<number, number>>({});
+
+  const totalAnswered = Object.keys(answers).length;
+  const isFinished = totalAnswered === questions.length;
+  const score = Object.entries(answers).filter(
+    ([i, selected]) => questions[Number(i)].answer === selected
+  ).length;
+
+  function handleAnswer(questionIndex: number, optionIndex: number) {
+    if (answers[questionIndex] !== undefined) return;
+    setAnswers((prev) => ({ ...prev, [questionIndex]: optionIndex }));
+  }
+
+  return (
+    <Layout withInstagram={false}>
+
+      {/* ── EN-TÊTE ───────────────────────────────────────────────── */}
+      <section className="mx-auto mb-12 mt-8 w-11/12 max-w-3xl border-b border-neutral-200 pb-8">
+        <p className="mb-2 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
+          Été 2026 · Quiz
+        </p>
+        <h1 className="font-display text-4xl font-light leading-tight text-neutral-900 md:text-5xl">
+          Connaissez-vous les femmes artistes ?
+        </h1>
+        <p className="mt-4 max-w-xl text-sm font-light leading-relaxed text-neutral-500">
+          10 questions pour tester vos connaissances sur les femmes artistes
+          qui ont façonné l'Histoire de l'Art. Bonne chance !
+        </p>
+      </section>
+
+      {/* ── QUESTIONS ─────────────────────────────────────────────── */}
+      <div className="mx-auto mb-16 w-11/12 max-w-3xl space-y-10">
+        {questions.map((q, qi) => {
+          const selected = answers[qi];
+          const isAnswered = selected !== undefined;
+
+          return (
+            <article key={qi} className="border border-neutral-200">
+
+              {/* Question */}
+              <div className="border-b border-neutral-200 px-6 py-5">
+                <p className="mb-1 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
+                  Question {qi + 1}
+                </p>
+                <p className="font-display text-xl font-light leading-snug text-neutral-900">
+                  {q.question}
+                </p>
+              </div>
+
+              {/* Options */}
+              <div className="divide-y divide-neutral-100">
+                {q.options.map((option, oi) => {
+                  const isSelected = selected === oi;
+                  const isCorrect = q.answer === oi;
+
+                  let style =
+                    'w-full px-6 py-4 text-left text-sm font-light text-neutral-600 transition-colors hover:bg-neutral-50';
+
+                  if (isAnswered) {
+                    if (isCorrect) {
+                      style =
+                        'w-full px-6 py-4 text-left text-sm font-light bg-neutral-900 text-white';
+                    } else if (isSelected) {
+                      style =
+                        'w-full px-6 py-4 text-left text-sm font-light bg-neutral-100 text-neutral-400 line-through';
+                    } else {
+                      style =
+                        'w-full px-6 py-4 text-left text-sm font-light text-neutral-300';
+                    }
+                  }
+
+                  return (
+                    <button
+                      key={oi}
+                      onClick={() => handleAnswer(qi, oi)}
+                      disabled={isAnswered}
+                      className={style}
+                      aria-pressed={isSelected}
+                    >
+                      <span className="mr-3 text-xs font-semibold uppercase tracking-[0.2em]">
+                        {['A', 'B', 'C'][oi]}.
+                      </span>
+                      {option}
+                      {isAnswered && isCorrect && (
+                        <span className="ml-3 text-xs font-semibold uppercase tracking-[0.2em]">
+                          ✓
+                        </span>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+
+              {/* Explication */}
+              {isAnswered && (
+                <div className="border-t border-neutral-200 bg-neutral-50 px-6 py-5">
+                  <p className="mb-1 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
+                    {selected === q.answer ? 'Bonne réponse !' : 'Pas tout à fait…'}
+                  </p>
+                  <p className="font-display text-base font-light italic leading-relaxed text-neutral-600">
+                    {q.explanation}
+                  </p>
+                </div>
+              )}
+
+            </article>
+          );
+        })}
+      </div>
+
+      {/* ── SCORE FINAL ───────────────────────────────────────────── */}
+      {isFinished && (
+        <section className="mx-auto mb-20 w-11/12 max-w-3xl border border-neutral-200 bg-neutral-900 px-8 py-10 text-center">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-[0.25em] text-white/40">
+            Résultat Final
+          </p>
+          <p className="font-display text-5xl font-light text-white">
+            {score} / {questions.length}
+          </p>
+          <p className="mt-3 font-display text-xl font-light italic text-white/60">
+            {score <= 3 && "De belles découvertes à faire — le podcast est là pour ça !"}
+            {score >= 4 && score <= 6 && "Pas mal ! Vous connaissez déjà quelques-unes de ces femmes remarquables."}
+            {score >= 7 && score <= 9 && "Excellent ! Vous êtes une vraie passionnée d'Histoire de l'Art au féminin."}
+            {score === 10 && "Parfait ! Vous méritez un épisode entier rien que pour vous."}
+          </p>
+          <div className="mt-8 flex flex-wrap justify-center gap-3">
+            <Link
+              to="/podcasts"
+              className="border border-white/20 px-6 py-3 text-xs font-semibold uppercase tracking-[0.2em] text-white/60 transition-colors hover:border-white/60 hover:text-white"
+            >
+              Écouter le Podcast <span aria-hidden="true">→</span>
+            </Link>
+            <Link
+              to="/articles"
+              className="border border-white/20 px-6 py-3 text-xs font-semibold uppercase tracking-[0.2em] text-white/60 transition-colors hover:border-white/60 hover:text-white"
+            >
+              Lire les Articles <span aria-hidden="true">→</span>
+            </Link>
+          </div>
+        </section>
+      )}
+
+    </Layout>
+  );
+}
+
+export const Head = ({ location }: { location: { pathname: string } }) => (
+  <SEO
+    title="Quiz Été 2026 — Connaissez-vous les femmes artistes ? — ART AU FÉMININ"
+    description="10 questions pour tester vos connaissances sur les femmes artistes qui ont façonné l'Histoire de l'Art. Frida Kahlo, Louise Bourgeois, Artemisia Gentileschi et bien d'autres."
+    url={`https://www.artaufeminin.fr${location.pathname}`}
+  />
+);

--- a/src/templates/episode.tsx
+++ b/src/templates/episode.tsx
@@ -18,6 +18,8 @@ export default function Episode({ pageContext }) {
   const image = pageContext.itunes.image;
   const summary = pageContext.itunes.summary;
   const plainSummary = summary ? stripHtml(summary) : '';
+  const transcriptUrl = pageContext.transcriptUrl || null;
+  const transcriptText = pageContext.transcriptText || null;
 
   const audioPlayerData = useMemo(
     () => ({
@@ -122,6 +124,45 @@ export default function Episode({ pageContext }) {
             Soutenir sur Tipeee
           </a>
         </section>
+
+        <hr className="separator" />
+
+        {/* ── TRANSCRIPTION ─────────────────────────────────────── */}
+        {transcriptText && (
+          <section className="my-10 border border-neutral-200" aria-labelledby="transcript-heading">
+            <details>
+              <summary className="flex cursor-pointer items-center justify-between p-6 marker:content-none">
+                <div>
+                  <p id="transcript-heading" className="mb-1 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
+                    Transcription
+                  </p>
+                  <p className="text-sm font-light text-neutral-500">
+                    Lire la transcription complète de cet épisode
+                  </p>
+                </div>
+                <span className="shrink-0 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
+                  + Afficher
+                </span>
+              </summary>
+              <div className="border-t border-neutral-200 px-6 py-8">
+                <p className="whitespace-pre-line text-sm font-light leading-relaxed text-neutral-600">
+                  {transcriptText}
+                </p>
+                {transcriptUrl && (
+                  <a
+                    href={transcriptUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label={`Télécharger la transcription de l'épisode : ${title} (ouvre un nouvel onglet)`}
+                    className="mt-6 inline-block text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors hover:text-neutral-900"
+                  >
+                    Télécharger le fichier <span aria-hidden="true">→</span>
+                  </a>
+                )}
+              </div>
+            </details>
+          </section>
+        )}
 
         <hr className="separator" />
       </div>


### PR DESCRIPTION
## Quiz Été 2026

Page interactive `/quiz-ete-2026/` à partager dans la newsletter d'été :

- **10 questions** sur les femmes artistes (Louise Bourgeois, Guerrilla Girls, VALIE EXPORT, Hilma af Klint, Berthe Morisot, Edmonia Lewis, Frida Kahlo, Yayoi Kusama, Artemisia Gentileschi, Käthe Kollwitz)
- Révélation instantanée : bonne réponse en noir/blanc, mauvaise réponse barrée
- Explication contextuelle après chaque réponse
- Score final avec message personnalisé + liens vers `/podcasts` et `/articles`
- Design fidèle à la charte graphique (Cormorant Garamond, minimaliste)

## Pipeline Transcription (prêt, en attente du flux RSS)

Infrastructure complète pour intégrer les transcriptions des épisodes pour le SEO Google :

- **Plugin local** `plugins/gatsby-source-anchor-transcript/` : parse le champ `podcast:transcript` depuis le flux RSS Anchor/Spotify (formats JSON Spotify, SRT, VTT)
- **`gatsby-node.js`** : fetch des transcriptions à la construction (Node.js natif, pas de dépendance supplémentaire)
- **`episode.tsx`** : affichage via `<details>/<summary>` — Google indexe le contenu, utilisateurs l'ouvrent à la demande

> En attente que Spotify for Podcasters exporte les tags `podcast:transcript` dans le flux RSS. Dès qu'ils apparaissent, tout s'active automatiquement.

## Test plan

- [ ] `gatsby develop` — vérifier `/quiz-ete-2026/` en local
- [ ] Cliquer chaque option : vérifier révélation + explication
- [ ] Répondre aux 10 questions : vérifier le score final
- [ ] Vérifier les liens "Écouter le Podcast" et "Lire les Articles"
- [ ] Build de production : `gatsby build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)