### PR TITLE
fix(quiz): guillemets cassés + type GraphQL transcriptUrl

### DIFF
--- a/plugins/gatsby-source-anchor-transcript/gatsby-node.js
+++ b/plugins/gatsby-source-anchor-transcript/gatsby-node.js
@@ -2,6 +2,17 @@
 
 const Parser = require('rss-parser')
 
+// Explicitly define the AnchorEpisode type so transcriptUrl is always
+// present in the GraphQL schema, even when null for all episodes.
+exports.createSchemaCustomization = ({ actions }) => {
+  const { createTypes } = actions
+  createTypes(`
+    type AnchorEpisode implements Node {
+      transcriptUrl: String
+    }
+  `)
+}
+
 exports.sourceNodes = async (
   { actions, createContentDigest },
   configOptions

--- a/src/pages/quiz-ete-2026.tsx
+++ b/src/pages/quiz-ete-2026.tsx
@@ -6,11 +6,11 @@ import SEO from '../components/seo';
 
 const questions = [
   {
-    question: "Qui a créé la sculpture géante "Maman", représentant une araignée ?",
-    options: ["Yayoi Kusama", "Louise Bourgeois", "Camille Claudel"],
+    question: 'Qui a créé la sculpture géante «Maman», représentant une araignée ?',
+    options: ['Yayoi Kusama', 'Louise Bourgeois', 'Camille Claudel'],
     answer: 1,
     explanation:
-      "Louise Bourgeois a créé "Maman" en 1999 pour l'inauguration de la Tate Modern à Londres. L'araignée représente sa mère, restauratrice de tapisseries — patiente, habile et indispensable comme une araignée.",
+      "Louise Bourgeois a créé «Maman» en 1999 pour l'inauguration de la Tate Modern à Londres. L'araignée représente sa mère, restauratrice de tapisseries — patiente, habile et indispensable comme une araignée.",
   },
   {
     question: "En quelle année les Guerrilla Girls ont-elles été fondées ?",
@@ -32,7 +32,7 @@ const questions = [
     options: ["1 an", "5 ans", "10 ans"],
     answer: 1,
     explanation:
-      "Kandinsky est souvent cité comme le père de l'abstraction avec ses premières aquarelles abstraites vers 1911. Hilma af Klint peignait ses "Peintures pour le Temple" dès 1906 — cinq ans avant lui.",
+      "Kandinsky est souvent cité comme le père de l'abstraction avec ses premières aquarelles abstraites vers 1911. Hilma af Klint peignait ses «Peintures pour le Temple» dès 1906 — cinq ans avant lui.",
   },
   {
     question:
@@ -48,14 +48,14 @@ const questions = [
     options: ["Hagar in the Wilderness", "Portrait of Lincoln", "The Death of Cleopatra"],
     answer: 2,
     explanation:
-      ""The Death of Cleopatra" (1876) a disparu après l'Exposition universelle de Philadelphie. Elle a servi de décoration dans un hippodrome du Illinois avant d'être retrouvée et restaurée. Elle est aujourd'hui conservée au Smithsonian American Art Museum de Washington.",
+      "«The Death of Cleopatra» (1876) a disparu après l'Exposition universelle de Philadelphie. Elle a servi de décoration dans un hippodrome du Illinois avant d'être retrouvée et restaurée. Elle est aujourd'hui conservée au Smithsonian American Art Museum de Washington.",
   },
   {
     question: "Pourquoi Frida Kahlo réalisait-elle autant d'autoportraits ?",
     options: [
-      ""Parce que les galeries l'exigeaient"",
-      ""Parce que je manque de modèles"",
-      ""Parce que je suis souvent seule et suis le sujet que je connais le mieux"",
+      '«Parce que les galeries l\'exigeaient»',
+      '«Parce que je manque de modèles»',
+      '«Parce que je suis souvent seule et suis le sujet que je connais le mieux»',
     ],
     answer: 2,
     explanation:


### PR DESCRIPTION
## Problèmes résolus

### 1. Build cassé — guillemets non échappés
Les titres d'œuvres comme `"Maman"` et `"Peintures pour le Temple"` étaient écrits avec des `"` droits à l'intérieur de strings délimitées par `"`, cassant le parsing Babel/TypeScript.

**Fix :** remplacement par des guillemets français `«»` (plus correct typographiquement pour du texte français).

### 2. Build cassé — champ `transcriptUrl` absent du schéma GraphQL
Gatsby infère les types depuis les données. Comme aucun épisode n'a encore de transcription, `transcriptUrl` était `null` partout → absent du schéma → `Cannot query field "transcriptUrl"`.

**Fix :** ajout de `createSchemaCustomization` dans le plugin local pour déclarer explicitement `transcriptUrl: String`.

## Test plan

- [x] `gatsby build` local réussi sans erreur
- [ ] Vérifier `/quiz-ete-2026/` en production après merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)