### PR TITLE
fix(netlify): ajoute netlify.toml pour stabiliser le build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+  command = "yarn build"
+  publish = "public"
+
+[build.environment]
+  NODE_VERSION = "20"


### PR DESCRIPTION
## Problème

Le build Netlify échoue depuis le PR #220. Sans `netlify.toml`, Netlify utilise une version de Node.js par défaut qui peut différer de l'environnement local (Node 22).

## Fix

Création d'un `netlify.toml` minimal qui :
- Force Node.js 20 (LTS stable, compatible Gatsby 5)
- Déclare explicitement `yarn build` comme commande
- Déclare `public/` comme répertoire de publication

## Test plan

- [ ] Vérifier que le build Netlify passe
- [ ] Vérifier `/quiz-ete-2026/` en production

🤖 Generated with [Claude Code](https://claude.com/claude-code)