### PR TITLE
fix: supprime le pipeline transcription

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -2,67 +2,6 @@
 // https://www.gatsbyjs.com/docs/reference/config-files/gatsby-node/
 
 const path = require(`path`)
-const https = require(`https`)
-const http = require(`http`)
-
-// Fetch a URL and return the body as a string
-function fetchUrl(url) {
-  return new Promise((resolve, reject) => {
-    const client = url.startsWith('https') ? https : http
-    client.get(url, (res) => {
-      let data = ''
-      res.on('data', (chunk) => { data += chunk })
-      res.on('end', () => resolve({ body: data, contentType: res.headers['content-type'] || '' }))
-    }).on('error', reject)
-  })
-}
-
-// Parse SRT or VTT subtitles → plain text
-function parseSrtOrVtt(text) {
-  return text
-    .split('\n')
-    .filter((line) => {
-      const trimmed = line.trim()
-      if (!trimmed || trimmed === 'WEBVTT') return false
-      if (/^\d+$/.test(trimmed)) return false                          // SRT sequence numbers
-      if (/-->/i.test(trimmed)) return false                          // timestamp lines
-      return true
-    })
-    .join(' ')
-    .replace(/\s+/g, ' ')
-    .trim()
-}
-
-// Parse Spotify/Apple JSON transcript → plain text
-function parseJsonTranscript(json) {
-  try {
-    const data = JSON.parse(json)
-    // Spotify format: { segments: [{ body: "..." }] }
-    if (Array.isArray(data.segments)) {
-      return data.segments.map((s) => s.body || s.text || '').join(' ').trim()
-    }
-    // Generic array fallback
-    if (Array.isArray(data)) {
-      return data.map((s) => s.body || s.text || s.content || '').join(' ').trim()
-    }
-    return ''
-  } catch {
-    return ''
-  }
-}
-
-async function fetchTranscriptText(url) {
-  try {
-    const { body, contentType } = await fetchUrl(url)
-    if (contentType.includes('json') || url.endsWith('.json')) {
-      return parseJsonTranscript(body)
-    }
-    // SRT or VTT
-    return parseSrtOrVtt(body)
-  } catch {
-    return null
-  }
-}
 
 // Log out information after a build is done
 exports.onPostBuild = ({ reporter }) => {
@@ -126,7 +65,6 @@ exports.createPages = async ({ graphql, actions }) => {
           contentSnippet
           link
           title
-          transcriptUrl
           itunes {
             summary
             image
@@ -141,7 +79,7 @@ exports.createPages = async ({ graphql, actions }) => {
       }
     }
   `)
-  for (const node of podcats.data.allAnchorEpisode.nodes) {
+  podcats.data.allAnchorEpisode.nodes.forEach((node) => {
     // Redirect old url to new url needs to be before `createPage`
     createRedirect({
       fromPath: `/podcast/${node.guid}`,
@@ -149,26 +87,14 @@ exports.createPages = async ({ graphql, actions }) => {
       isPermanent: true,
     })
 
-    // Fetch transcript content at build time so Google can index it
-    let transcriptText = null
-    if (node.transcriptUrl) {
-      transcriptText = await fetchTranscriptText(node.transcriptUrl)
-      if (transcriptText) {
-        console.info(`  ✅ Transcript fetched for: ${node.title}`)
-      } else {
-        console.warn(`  ⚠️  Could not parse transcript for: ${node.title}`)
-      }
-    }
-
     createPage({
       path: `podcasts/${node.guid}`,
       component: episodeTemplate,
       context: {
         ...node,
-        transcriptText,
       },
     })
-  }
+  })
 
   const articleTemplate = path.resolve(`src/templates/article.tsx`)
   const articles = await graphql(`

--- a/plugins/gatsby-source-anchor-transcript/gatsby-node.js
+++ b/plugins/gatsby-source-anchor-transcript/gatsby-node.js
@@ -2,17 +2,6 @@
 
 const Parser = require('rss-parser')
 
-// Explicitly define the AnchorEpisode type so transcriptUrl is always
-// present in the GraphQL schema, even when null for all episodes.
-exports.createSchemaCustomization = ({ actions }) => {
-  const { createTypes } = actions
-  createTypes(`
-    type AnchorEpisode implements Node {
-      transcriptUrl: String
-    }
-  `)
-}
-
 exports.sourceNodes = async (
   { actions, createContentDigest },
   configOptions
@@ -24,18 +13,7 @@ exports.sourceNodes = async (
     throw new Error('[gatsby-source-anchor-transcript] rss must be a valid URL')
   }
 
-  console.time('\nAnchor podcast fetched in')
-
-  // Parse podcast:transcript custom field from the RSS
-  const parser = new Parser({
-    customFields: {
-      item: [
-        ['podcast:transcript', 'transcript'],
-        ['psc:chapters', 'chapters'],
-      ],
-    },
-  })
-
+  const parser = new Parser()
   const feed = await parser.parseURL(rss)
 
   if (!feed || !feed.title) {
@@ -44,26 +22,10 @@ exports.sourceNodes = async (
     )
   }
 
-  const getEpisodeId = (guid) => `anchor-episode-${guid}`
-
   for (const item of feed.items) {
-    // Normalize transcript field — rss-parser returns either a string (url)
-    // or an object with $ attributes depending on the XML structure
-    let transcriptUrl = null
-    if (item.transcript) {
-      if (typeof item.transcript === 'string') {
-        transcriptUrl = item.transcript
-      } else if (item.transcript.$ && item.transcript.$.url) {
-        transcriptUrl = item.transcript.$.url
-      }
-    }
-
     const node = {
       ...item,
-      transcriptUrl,
-      // Remove raw transcript field — we expose transcriptUrl instead
-      transcript: undefined,
-      id: getEpisodeId(item.guid),
+      id: `anchor-episode-${item.guid}`,
       parent: null,
       children: [],
       internal: {
@@ -76,6 +38,4 @@ exports.sourceNodes = async (
 
     createNode(node)
   }
-
-  console.timeEnd('\nAnchor podcast fetched in')
 }

--- a/plugins/gatsby-source-anchor-transcript/package.json
+++ b/plugins/gatsby-source-anchor-transcript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-source-anchor-transcript",
   "version": "1.0.0",
-  "description": "Local Gatsby plugin — extends gatsby-source-anchor with podcast:transcript support",
+  "description": "Local Gatsby plugin — source AnchorEpisode nodes from RSS feed",
   "main": "gatsby-node.js",
   "dependencies": {
     "rss-parser": "^3.13.0"

--- a/src/templates/episode.tsx
+++ b/src/templates/episode.tsx
@@ -18,9 +18,6 @@ export default function Episode({ pageContext }) {
   const image = pageContext.itunes.image;
   const summary = pageContext.itunes.summary;
   const plainSummary = summary ? stripHtml(summary) : '';
-  const transcriptUrl = pageContext.transcriptUrl || null;
-  const transcriptText = pageContext.transcriptText || null;
-
   const audioPlayerData = useMemo(
     () => ({
       title,
@@ -124,45 +121,6 @@ export default function Episode({ pageContext }) {
             Soutenir sur Tipeee
           </a>
         </section>
-
-        <hr className="separator" />
-
-        {/* ── TRANSCRIPTION ─────────────────────────────────────── */}
-        {transcriptText && (
-          <section className="my-10 border border-neutral-200" aria-labelledby="transcript-heading">
-            <details>
-              <summary className="flex cursor-pointer items-center justify-between p-6 marker:content-none">
-                <div>
-                  <p id="transcript-heading" className="mb-1 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
-                    Transcription
-                  </p>
-                  <p className="text-sm font-light text-neutral-500">
-                    Lire la transcription complète de cet épisode
-                  </p>
-                </div>
-                <span className="shrink-0 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
-                  + Afficher
-                </span>
-              </summary>
-              <div className="border-t border-neutral-200 px-6 py-8">
-                <p className="whitespace-pre-line text-sm font-light leading-relaxed text-neutral-600">
-                  {transcriptText}
-                </p>
-                {transcriptUrl && (
-                  <a
-                    href={transcriptUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    aria-label={`Télécharger la transcription de l'épisode : ${title} (ouvre un nouvel onglet)`}
-                    className="mt-6 inline-block text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors hover:text-neutral-900"
-                  >
-                    Télécharger le fichier <span aria-hidden="true">→</span>
-                  </a>
-                )}
-              </div>
-            </details>
-          </section>
-        )}
 
         <hr className="separator" />
       </div>


### PR DESCRIPTION
## Problème

Le pipeline transcription ajouté dans les PRs précédents causait des erreurs de build Netlify (plugin local complexe, dépendance rss-parser non reconnue).

## Changements

- **Plugin local simplifié** : plus que le strict nécessaire — parse le flux RSS Anchor et crée les nœuds `AnchorEpisode`. Pas de `createSchemaCustomization`, pas de champ `transcriptUrl`.
- **`gatsby-node.js`** : suppression de `fetchUrl`, `parseSrtOrVtt`, `parseJsonTranscript`, `fetchTranscriptText` et du champ `transcriptUrl` dans la query GraphQL.
- **`episode.tsx`** : suppression de la section `<details>` de transcription.

Le travail sur les transcriptions pourra être repris plus tard quand Spotify exporte correctement les tags `podcast:transcript`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)