### PR TITLE
fix(netlify): force Yarn 4 pour corriger le build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,4 @@
 
 [build.environment]
   NODE_VERSION = "20"
+  YARN_VERSION = "4"


### PR DESCRIPTION
## Cause racine identifiée

Le projet utilise **Yarn 4.9.2** (Berry) dont le format de `yarn.lock` est incompatible avec Yarn 1 — la version utilisée par défaut par Netlify. Résultat : `yarn install` échoue au build, ce qui explique tous les échecs depuis le PR #220.

## Fix

Ajout de `YARN_VERSION = "4"` dans `netlify.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)