### PR TITLE
fix(seo): retire noindex sur la page galerie

### DIFF
--- a/src/pages/galerie.tsx
+++ b/src/pages/galerie.tsx
@@ -136,6 +136,5 @@ export const Head = ({ location }: { location: { pathname: string } }) => (
     title="Galerie ART AU FÉMININ — Découvrez les Artistes en avant-première"
     description="Une galerie d'Art immersive en 3D dédiée aux femmes artistes. Première exposition : Sororité, ~20 artistes. Recevez le catalogue complet en vous inscrivant."
     url={`https://www.artaufeminin.fr${location.pathname}`}
-    noindex={true}
   />
 );


### PR DESCRIPTION
## Summary
- Retire `noindex={true}` sur la page `/galerie/` pour permettre l'indexation par Google

## Test plan
- [ ] Vérifier dans Google Search Console que la page est bien indexable après déploiement
- [ ] Demander une re-exploration de l'URL dans GSC

🤖 Generated with [Claude Code](https://claude.com/claude-code)