### PR TITLE
fix(netlify): retour à la config minimale sans Yarn overrides

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,5 +4,4 @@
 
 [build.environment]
   NODE_VERSION = "20"
-  YARN_VERSION = "4"
   ENABLE_COREPACK = "1"

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,4 +4,3 @@
 
 [build.environment]
   NODE_VERSION = "20"
-  ENABLE_COREPACK = "1"


### PR DESCRIPTION
## Problème

Les tentatives successives de fix Yarn ont laissé `YARN_VERSION=4` et `ENABLE_COREPACK=1` dans netlify.toml. Ces deux options peuvent interférer entre elles.

## Solution

Retour à l'état initial : juste `NODE_VERSION = "20"`, sans aucun override Yarn. C'est la config qui fonctionnait avant les modifications du 16 mai.

## Test

Après merge → vérifier dans Netlify → Deploys que le build passe ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)