### PR TITLE
fix: corrige les apostrophes qui cassaient le build Gatsby depuis le 22 mai

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -372,9 +372,9 @@ export const Head = ({ location }: { location: { pathname: string } }) => {
       keywords: [
         'femmes artistes',
         'artistes femmes',
-        'histoire de l'art',
+        "histoire de l'art",
         'podcast art',
-        'femmes dans l'art',
+        "femmes dans l'art",
         'artistes oubliées',
         'histoire des femmes',
         'art au féminin',

--- a/src/templates/article.tsx
+++ b/src/templates/article.tsx
@@ -247,7 +247,7 @@ export const Head = (
       '@type': 'BlogPosting',
       headline: seoTitle,
       description: seoDescription,
-      keywords: ['femmes artistes', 'histoire de l'art', 'art au féminin', 'artistes femmes'],
+      keywords: ['femmes artistes', "histoire de l'art", 'art au féminin', 'artistes femmes'],
       image:
         seoImage ||
         'https://raw.githubusercontent.com/flexbox/artaufeminin/master/src/images/logo-podcast-art-au-feminin.png',

--- a/src/templates/episode.tsx
+++ b/src/templates/episode.tsx
@@ -198,7 +198,7 @@ export const Head = ({
       '@type': 'PodcastEpisode',
       name: title,
       description,
-      keywords: ['femmes artistes', 'podcast art', 'histoire de l'art', 'art au féminin', 'artistes femmes'],
+      keywords: ['femmes artistes', 'podcast art', "histoire de l'art", 'art au féminin', 'artistes femmes'],
       url: canonicalUrl,
       ...(episodeImage && { image: episodeImage }),
       inLanguage: 'fr',


### PR DESCRIPTION
## Cause du problème

Les keywords ajoutés dans les JSON-LD le 22 mai contenaient des apostrophes simples à l'intérieur de strings délimitées par des guillemets simples :

```js
// ❌ AVANT — syntaxe JavaScript invalide
'histoire de l'art'
'femmes dans l'art'
```

Le `'` dans `l'art` fermait la string prématurément → **erreur de syntaxe → build Gatsby en échec depuis le 22 mai**.

## Fix

```js
// ✅ APRÈS — guillemets doubles pour les strings avec apostrophes
"histoire de l'art"
"femmes dans l'art"
```

## Fichiers corrigés

- `src/pages/index.tsx`
- `src/templates/article.tsx`
- `src/templates/episode.tsx`

## Impact

Les builds automatiques déclenchés par Prismic vont à nouveau fonctionner. Les articles publiés dans Prismic réapparaîtront sur le site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)