### PR TITLE
feat(legal): RGPD, RGAA et consentement newsletter

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -188,21 +188,35 @@ export default function Footer({ siteTitle }: FooterProps) {
         </div>
 
         {/* ── Bas de page ─────────────────────────────────────── */}
-        <div className="border-t border-white/10 py-8 lg:flex lg:items-center lg:justify-between">
-          <p className="text-xs font-light text-white/30">
-            &copy; {new Date().getFullYear()} {siteTitle} — Tous droits réservés.
-          </p>
-          <p className="mt-2 text-xs font-light text-white/20 lg:mt-0">
-            Fait avec passion par{' '}
-            <a
-              href="https://aldjia.dev"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-white/40 transition-colors hover:text-white/70"
-            >
-              Aldjia Boughias
-            </a>
-          </p>
+        <div className="border-t border-white/10 py-8">
+          <div className="lg:flex lg:items-center lg:justify-between">
+            <p className="text-xs font-light text-white/30">
+              &copy; {new Date().getFullYear()} {siteTitle} — Tous droits réservés.
+            </p>
+            <p className="mt-2 text-xs font-light text-white/20 lg:mt-0">
+              Fait avec passion par{' '}
+              <a
+                href="https://aldjia.dev"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Site d'Aldjia Boughias (ouvre un nouvel onglet)"
+                className="text-white/40 transition-colors hover:text-white/70"
+              >
+                Aldjia Boughias
+              </a>
+            </p>
+          </div>
+          <nav aria-label="Liens légaux" className="mt-4 flex flex-wrap gap-4">
+            <Link to="/mentions-legales" className="text-xs font-light text-white/25 transition-colors hover:text-white/60">
+              Mentions légales
+            </Link>
+            <Link to="/politique-confidentialite" className="text-xs font-light text-white/25 transition-colors hover:text-white/60">
+              Politique de confidentialité
+            </Link>
+            <Link to="/accessibilite" className="text-xs font-light text-white/25 transition-colors hover:text-white/60">
+              Accessibilité
+            </Link>
+          </nav>
         </div>
 
       </div>

--- a/src/components/newsletter.tsx
+++ b/src/components/newsletter.tsx
@@ -1,11 +1,14 @@
+import { Link } from 'gatsby';
 import React, { ReactElement, useState } from 'react';
 
 export default function Newsletter(): ReactElement {
   const [email, setEmail] = useState('');
+  const [consent, setConsent] = useState(false);
   const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
+    if (!consent) return;
     setStatus('loading');
     try {
       const body = new FormData();
@@ -39,28 +42,54 @@ export default function Newsletter(): ReactElement {
       ) : (
         <form onSubmit={handleSubmit} className="mt-6">
           <div className="flex gap-0">
+            <label htmlFor="newsletter-email" className="sr-only">
+              Adresse email
+            </label>
             <input
+              id="newsletter-email"
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               autoComplete="email"
               required
               aria-required="true"
-              aria-label="Adresse email"
               placeholder="votre@email.fr"
               className="min-w-0 flex-1 rounded-l-full border border-white/30 bg-white/20 px-5 py-3 text-sm text-white placeholder:text-white/60 focus:bg-white/30 focus:outline-none transition-colors"
             />
             <button
               type="submit"
-              disabled={status === 'loading'}
+              disabled={status === 'loading' || !consent}
               aria-label={status === 'loading' ? 'Envoi en cours…' : "S'inscrire à la newsletter"}
-              className="rounded-r-full border border-white/20 border-l-0 bg-clay-500 px-5 py-3 text-xs font-bold uppercase tracking-widest text-white transition-colors hover:bg-clay-700 disabled:opacity-60"
+              className="rounded-r-full border border-white/20 border-l-0 bg-clay-500 px-5 py-3 text-xs font-bold uppercase tracking-widest text-white transition-colors hover:bg-clay-700 disabled:opacity-40"
             >
               <span aria-hidden="true">{status === 'loading' ? '…' : '→'}</span>
             </button>
           </div>
+
+          <div className="mt-3 flex items-start gap-2">
+            <input
+              id="newsletter-consent"
+              type="checkbox"
+              checked={consent}
+              onChange={(e) => setConsent(e.target.checked)}
+              required
+              aria-required="true"
+              className="mt-0.5 size-3.5 shrink-0 accent-clay-500 cursor-pointer"
+            />
+            <label htmlFor="newsletter-consent" className="text-xs font-light leading-relaxed text-white/40 cursor-pointer">
+              J'accepte de recevoir la newsletter d'ART AU FÉMININ et je reconnais avoir lu la{' '}
+              <Link
+                to="/politique-confidentialite"
+                className="text-white/60 underline underline-offset-2 hover:text-white/90"
+              >
+                politique de confidentialité
+              </Link>.
+              Désinscription possible à tout moment.
+            </label>
+          </div>
+
           {status === 'error' && (
-            <p className="mt-2 text-xs text-red-300">
+            <p className="mt-2 text-xs text-red-300" role="alert">
               Une erreur s'est produite. Veuillez réessayer.
             </p>
           )}

--- a/src/pages/accessibilite.tsx
+++ b/src/pages/accessibilite.tsx
@@ -1,0 +1,204 @@
+import React from 'react';
+
+import Layout from '../components/layout';
+import SEO from '../components/seo';
+
+export default function AccessibilitePage() {
+  return (
+    <Layout withInstagram={false} withLastPodcast={false}>
+      <section className="m-auto mb-12 mt-8 w-3/4 max-w-3xl">
+        <p className="mb-2 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
+          Accessibilité
+        </p>
+        <h1 className="font-display text-4xl font-light leading-tight text-neutral-900 md:text-5xl">
+          Déclaration d'Accessibilité
+        </h1>
+        <p className="mt-4 text-xs font-light text-neutral-400">
+          Conformément au Référentiel Général d'Amélioration de l'Accessibilité (RGAA 4.1).
+          Dernière mise à jour : mai 2025.
+        </p>
+      </section>
+
+      <div className="m-auto mb-20 w-3/4 max-w-3xl space-y-10">
+
+        <section aria-labelledby="engagement-heading">
+          <h2 id="engagement-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+            Notre engagement
+          </h2>
+          <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600 space-y-3">
+            <p>
+              ART AU FÉMININ s'engage à rendre son site accessible conformément à l'article 47 de la loi n°2005-102 du 11 février 2005
+              et au RGAA version 4.1. Cette déclaration d'accessibilité s'applique au site{' '}
+              <strong className="font-medium text-neutral-800">artaufeminin.fr</strong>.
+            </p>
+          </div>
+        </section>
+
+        <section aria-labelledby="conformite-heading">
+          <h2 id="conformite-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+            État de conformité
+          </h2>
+          <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600 space-y-3">
+            <p>
+              Le site <strong className="font-medium text-neutral-800">artaufeminin.fr</strong> est en{' '}
+              <strong className="font-medium text-neutral-800">conformité partielle</strong> avec le RGAA 4.1.
+              Les non-conformités et les dérogations sont listées ci-dessous.
+            </p>
+          </div>
+        </section>
+
+        <section aria-labelledby="mesures-heading">
+          <h2 id="mesures-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+            Mesures prises pour l'accessibilité
+          </h2>
+          <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600">
+            <ul className="space-y-2 pl-4">
+              {[
+                'Langue de la page déclarée en français (lang="fr")',
+                'Lien d'évitement "Passer au contenu principal" en début de page',
+                'Structure de titres cohérente (h1, h2, h3) sur toutes les pages',
+                'Navigation clavier entièrement fonctionnelle avec focus visible',
+                'Attributs aria-label descriptifs sur tous les liens et boutons d'action',
+                'Alternatives textuelles sur toutes les images',
+                'Liens vers des ressources externes indiquant l'ouverture dans un nouvel onglet',
+                'Lecteurs d'écran : balises aria-hidden sur les éléments décoratifs',
+                'Points de repère ARIA (main, nav, footer) sur toutes les pages',
+                'Formulaire newsletter avec label explicite et indication des champs requis',
+              ].map((measure) => (
+                <li key={measure} className="flex items-start gap-2">
+                  <span className="mt-2 size-1 shrink-0 bg-neutral-400" />
+                  <span>{measure}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        <section aria-labelledby="non-conformites-heading">
+          <h2 id="non-conformites-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+            Non-conformités connues
+          </h2>
+          <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600 space-y-3">
+            <p>
+              Les éléments suivants ne sont pas encore pleinement conformes au RGAA 4.1 :
+            </p>
+            <ul className="space-y-2 pl-4">
+              {[
+                'Le lecteur audio intégré (composant custom) n'a pas fait l'objet d'un audit d'accessibilité complet.',
+                'Certains contenus enrichis issus de Prismic CMS peuvent ne pas inclure d'alternatives textuelles complètes selon les saisies.',
+                'La galerie 3D (expérience immersive) n'est pas accessible aux technologies d'assistance.',
+              ].map((item) => (
+                <li key={item} className="flex items-start gap-2">
+                  <span className="mt-2 size-1 shrink-0 bg-neutral-400" />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        <section aria-labelledby="technologies-heading">
+          <h2 id="technologies-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+            Technologies utilisées
+          </h2>
+          <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600">
+            <ul className="space-y-2 pl-4">
+              {['HTML5', 'CSS (Tailwind CSS)', 'JavaScript / TypeScript (React, Gatsby)', 'WAI-ARIA 1.2'].map((tech) => (
+                <li key={tech} className="flex items-start gap-2">
+                  <span className="mt-2 size-1 shrink-0 bg-neutral-400" />
+                  <span>{tech}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        <section aria-labelledby="outils-heading">
+          <h2 id="outils-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+            Outils d'évaluation utilisés
+          </h2>
+          <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600">
+            <ul className="space-y-2 pl-4">
+              {[
+                'Vérification manuelle au clavier (navigation sans souris)',
+                'Extension navigateur axe DevTools (audit automatique WCAG)',
+                'VoiceOver (macOS) pour les tests lecteur d'écran',
+              ].map((tool) => (
+                <li key={tool} className="flex items-start gap-2">
+                  <span className="mt-2 size-1 shrink-0 bg-neutral-400" />
+                  <span>{tool}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        <section aria-labelledby="contact-heading">
+          <h2 id="contact-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+            Contact — Signaler un problème d'accessibilité
+          </h2>
+          <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600 space-y-3">
+            <p>
+              Si vous rencontrez un obstacle à l'accessibilité sur ce site, merci de nous le signaler.
+              Nous ferons notre possible pour vous fournir une alternative accessible ou pour corriger le problème dans les meilleurs délais.
+            </p>
+            <p>
+              <strong className="font-medium text-neutral-800">Par e-mail :</strong>{' '}
+              <a
+                href="mailto:artaufemininlepodcast@gmail.com"
+                className="text-neutral-700 underline underline-offset-2 hover:text-neutral-900"
+              >
+                artaufemininlepodcast@gmail.com
+              </a>
+            </p>
+            <p className="text-xs text-neutral-400">
+              Nous nous engageons à répondre à votre demande dans un délai de 2 semaines ouvrées.
+            </p>
+          </div>
+        </section>
+
+        <section aria-labelledby="voie-recours-heading">
+          <h2 id="voie-recours-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+            Voie de recours
+          </h2>
+          <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600 space-y-3">
+            <p>
+              Si vous n'obtenez pas de réponse satisfaisante, vous pouvez contacter le Défenseur des droits :
+            </p>
+            <ul className="space-y-2 pl-4">
+              <li className="flex items-start gap-2">
+                <span className="mt-2 size-1 shrink-0 bg-neutral-400" />
+                <span>
+                  Via le formulaire de contact sur{' '}
+                  <a
+                    href="https://formulaire.defenseurdesdroits.fr"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label="Formulaire du Défenseur des droits (ouvre un nouvel onglet)"
+                    className="text-neutral-700 underline underline-offset-2 hover:text-neutral-900"
+                  >
+                    formulaire.defenseurdesdroits.fr
+                  </a>
+                </span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-2 size-1 shrink-0 bg-neutral-400" />
+                <span>Par courrier : Défenseur des droits — Libre réponse 71120 — 75342 Paris CEDEX 07</span>
+              </li>
+            </ul>
+          </div>
+        </section>
+
+      </div>
+    </Layout>
+  );
+}
+
+export const Head = ({ location }: { location: { pathname: string } }) => (
+  <SEO
+    title="Déclaration d'Accessibilité — ART AU FÉMININ"
+    description="Déclaration d'accessibilité numérique du site ART AU FÉMININ : état de conformité RGAA 4.1, mesures prises, non-conformités connues et contact pour signaler un problème."
+    url={`https://www.artaufeminin.fr${location.pathname}`}
+    noindex={true}
+  />
+);

--- a/src/pages/mentions-legales.tsx
+++ b/src/pages/mentions-legales.tsx
@@ -1,0 +1,149 @@
+import { Link } from 'gatsby';
+import React from 'react';
+
+import Layout from '../components/layout';
+import SEO from '../components/seo';
+
+export default function MentionsLegalesPage() {
+  return (
+    <Layout withInstagram={false} withLastPodcast={false}>
+      <section className="m-auto mb-12 mt-8 w-3/4 max-w-3xl">
+        <p className="mb-2 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
+          Légal
+        </p>
+        <h1 className="font-display text-4xl font-light leading-tight text-neutral-900 md:text-5xl">
+          Mentions Légales
+        </h1>
+        <p className="mt-4 text-xs font-light text-neutral-400">
+          Conformément à la loi n° 2004-575 du 21 juin 2004 pour la confiance dans l'économie numérique (LCEN).
+        </p>
+      </section>
+
+      <div className="m-auto mb-20 w-3/4 max-w-3xl space-y-10">
+
+        <section aria-labelledby="editeur-heading">
+          <h2 id="editeur-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+            Éditeur du site
+          </h2>
+          <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600 space-y-2">
+            <p><strong className="font-medium text-neutral-800">Nom :</strong> Aldjia Boughias</p>
+            <p><strong className="font-medium text-neutral-800">Qualité :</strong> Particulier — créatrice du podcast et du site ART AU FÉMININ</p>
+            <p>
+              <strong className="font-medium text-neutral-800">Contact :</strong>{' '}
+              <a
+                href="mailto:artaufemininlepodcast@gmail.com"
+                className="text-neutral-700 underline underline-offset-2 hover:text-neutral-900"
+              >
+                artaufemininlepodcast@gmail.com
+              </a>
+            </p>
+          </div>
+        </section>
+
+        <section aria-labelledby="hebergeur-heading">
+          <h2 id="hebergeur-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+            Hébergeur
+          </h2>
+          <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600 space-y-2">
+            <p><strong className="font-medium text-neutral-800">Société :</strong> Netlify, Inc.</p>
+            <p><strong className="font-medium text-neutral-800">Adresse :</strong> 44 Montgomery Street, Suite 300, San Francisco, California 94104, États-Unis</p>
+            <p>
+              <strong className="font-medium text-neutral-800">Site :</strong>{' '}
+              <a
+                href="https://www.netlify.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Site de Netlify (ouvre un nouvel onglet)"
+                className="text-neutral-700 underline underline-offset-2 hover:text-neutral-900"
+              >
+                www.netlify.com
+              </a>
+            </p>
+          </div>
+        </section>
+
+        <section aria-labelledby="propriete-heading">
+          <h2 id="propriete-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+            Propriété intellectuelle
+          </h2>
+          <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600 space-y-3">
+            <p>
+              L'ensemble du contenu de ce site (textes, images, sons, podcasts, logos, graphismes) est la propriété exclusive
+              d'Aldjia Boughias, sauf mention contraire explicite.
+            </p>
+            <p>
+              Toute reproduction, représentation, modification, publication ou adaptation de tout ou partie des éléments du site,
+              quel que soit le moyen ou le procédé utilisé, est interdite sans autorisation préalable écrite.
+            </p>
+            <p>
+              Toute exploitation non autorisée du site ou de l'un quelconque des éléments qu'il contient sera considérée
+              comme constitutive d'une contrefaçon et poursuivie conformément aux dispositions des articles L.335-2 et suivants
+              du Code de Propriété Intellectuelle.
+            </p>
+          </div>
+        </section>
+
+        <section aria-labelledby="responsabilite-heading">
+          <h2 id="responsabilite-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+            Limitation de responsabilité
+          </h2>
+          <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600 space-y-3">
+            <p>
+              L'éditeur s'efforce de fournir sur ce site des informations aussi précises que possible. Toutefois, il ne
+              pourra être tenu responsable des omissions, inexactitudes et carences dans la mise à jour, qu'elles soient
+              de son fait ou du fait des tiers partenaires qui lui fournissent ces informations.
+            </p>
+            <p>
+              Les informations présentes sur ce site sont non contractuelles et peuvent être modifiées à tout moment.
+              L'accès au site peut être interrompu à tout moment sans préavis.
+            </p>
+          </div>
+        </section>
+
+        <section aria-labelledby="cookies-heading">
+          <h2 id="cookies-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+            Cookies
+          </h2>
+          <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600 space-y-3">
+            <p>
+              Ce site ne dépose pas de cookies de pistage ou de publicité. Le service de newsletter (MailerLite) peut
+              utiliser des cookies fonctionnels lors de la confirmation d'inscription. Aucun outil d'analyse comportementale
+              tiers n'est activé sur ce site.
+            </p>
+            <p>
+              Pour en savoir plus sur la gestion de vos données personnelles, consultez notre{' '}
+              <Link
+                to="/politique-confidentialite"
+                className="text-neutral-700 underline underline-offset-2 hover:text-neutral-900"
+              >
+                Politique de confidentialité
+              </Link>.
+            </p>
+          </div>
+        </section>
+
+        <section aria-labelledby="droit-applicable-heading">
+          <h2 id="droit-applicable-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+            Droit applicable
+          </h2>
+          <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600">
+            <p>
+              Les présentes mentions légales sont soumises au droit français. En cas de litige, les tribunaux français
+              seront seuls compétents.
+            </p>
+          </div>
+        </section>
+
+      </div>
+    </Layout>
+  );
+}
+
+export const Head = ({ location }: { location: { pathname: string } }) => (
+  <SEO
+    title="Mentions Légales — ART AU FÉMININ"
+    description="Mentions légales du site ART AU FÉMININ : éditeur, hébergeur, propriété intellectuelle et informations réglementaires."
+    url={`https://www.artaufeminin.fr${location.pathname}`}
+    noindex={true}
+  />
+);

--- a/src/pages/politique-confidentialite.tsx
+++ b/src/pages/politique-confidentialite.tsx
@@ -1,0 +1,203 @@
+import { Link } from 'gatsby';
+import React from 'react';
+
+import Layout from '../components/layout';
+import SEO from '../components/seo';
+
+export default function PolitiqueConfidentialitePage() {
+  return (
+    <Layout withInstagram={false} withLastPodcast={false}>
+      <section className="m-auto mb-12 mt-8 w-3/4 max-w-3xl">
+        <p className="mb-2 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
+          Légal
+        </p>
+        <h1 className="font-display text-4xl font-light leading-tight text-neutral-900 md:text-5xl">
+          Politique de Confidentialité
+        </h1>
+        <p className="mt-4 text-xs font-light text-neutral-400">
+          Dernière mise à jour : mai 2025. Conformément au Règlement Général sur la Protection des Données (RGPD — UE 2016/679).
+        </p>
+      </section>
+
+      <div className="m-auto mb-20 w-3/4 max-w-3xl space-y-10">
+
+        <section aria-labelledby="responsable-heading">
+          <h2 id="responsable-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+            Responsable du traitement
+          </h2>
+          <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600 space-y-2">
+            <p><strong className="font-medium text-neutral-800">Nom :</strong> Aldjia Boughias</p>
+            <p>
+              <strong className="font-medium text-neutral-800">Contact :</strong>{' '}
+              <a
+                href="mailto:artaufemininlepodcast@gmail.com"
+                className="text-neutral-700 underline underline-offset-2 hover:text-neutral-900"
+              >
+                artaufemininlepodcast@gmail.com
+              </a>
+            </p>
+          </div>
+        </section>
+
+        <section aria-labelledby="donnees-heading">
+          <h2 id="donnees-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+            Données collectées
+          </h2>
+          <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600 space-y-3">
+            <p>
+              Ce site collecte uniquement l'adresse e-mail des personnes qui s'inscrivent à la newsletter ART AU FÉMININ.
+              Aucune autre donnée personnelle (nom, prénom, adresse postale, données de navigation) n'est collectée
+              ni conservée par l'éditeur du site.
+            </p>
+            <p>
+              Le site ne dispose pas de compte utilisateur, de formulaire de contact enregistré, ni d'outil de suivi comportemental.
+            </p>
+          </div>
+        </section>
+
+        <section aria-labelledby="finalite-heading">
+          <h2 id="finalite-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+            Finalité et base légale du traitement
+          </h2>
+          <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600 space-y-3">
+            <p>
+              <strong className="font-medium text-neutral-800">Finalité :</strong> envoi de la newsletter ART AU FÉMININ
+              (nouveaux épisodes, articles, actualités du podcast).
+            </p>
+            <p>
+              <strong className="font-medium text-neutral-800">Base légale :</strong> consentement explicite de la personne
+              concernée (article 6.1.a du RGPD). Vous pouvez retirer votre consentement à tout moment en vous désinscrivant
+              via le lien présent dans chaque e-mail.
+            </p>
+          </div>
+        </section>
+
+        <section aria-labelledby="sous-traitant-heading">
+          <h2 id="sous-traitant-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+            Sous-traitant — MailerLite
+          </h2>
+          <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600 space-y-3">
+            <p>
+              La gestion des abonnements et l'envoi des e-mails sont assurés par <strong className="font-medium text-neutral-800">MailerLite</strong>
+              {' '}(UAB "MailerLite", Paupio g. 46, Vilnius, LT-11341, Lituanie). MailerLite agit en tant que sous-traitant
+              conformément à un accord de traitement des données (DPA) et est certifié conforme au RGPD.
+            </p>
+            <p>
+              Vos données ne sont utilisées que pour l'envoi de la newsletter et ne sont jamais revendues à des tiers.
+            </p>
+          </div>
+        </section>
+
+        <section aria-labelledby="conservation-heading">
+          <h2 id="conservation-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+            Durée de conservation
+          </h2>
+          <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600">
+            <p>
+              Votre adresse e-mail est conservée tant que vous êtes abonné(e) à la newsletter. En cas de désinscription,
+              vos données sont supprimées dans les 30 jours suivant la demande.
+            </p>
+          </div>
+        </section>
+
+        <section aria-labelledby="droits-heading">
+          <h2 id="droits-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+            Vos droits
+          </h2>
+          <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600 space-y-3">
+            <p>Conformément au RGPD, vous disposez des droits suivants :</p>
+            <ul className="space-y-2 pl-4">
+              {[
+                { droit: 'Droit d'accès', desc: 'obtenir une copie des données vous concernant.' },
+                { droit: 'Droit de rectification', desc: 'faire corriger vos données si elles sont inexactes.' },
+                { droit: 'Droit à l'effacement', desc: 'demander la suppression de vos données.' },
+                { droit: 'Droit d'opposition', desc: 'vous opposer au traitement de vos données.' },
+                { droit: 'Droit à la portabilité', desc: 'recevoir vos données dans un format structuré.' },
+                { droit: 'Droit de retrait du consentement', desc: 'en vous désinscrivant à tout moment via le lien en bas de chaque e-mail.' },
+              ].map(({ droit, desc }) => (
+                <li key={droit} className="flex items-start gap-2">
+                  <span className="mt-2 size-1 shrink-0 bg-neutral-400" />
+                  <span>
+                    <strong className="font-medium text-neutral-800">{droit} :</strong> {desc}
+                  </span>
+                </li>
+              ))}
+            </ul>
+            <p>
+              Pour exercer vos droits, contactez-nous à{' '}
+              <a
+                href="mailto:artaufemininlepodcast@gmail.com"
+                className="text-neutral-700 underline underline-offset-2 hover:text-neutral-900"
+              >
+                artaufemininlepodcast@gmail.com
+              </a>. Vous disposez également du droit d'introduire une réclamation auprès de la{' '}
+              <a
+                href="https://www.cnil.fr"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Site de la CNIL (ouvre un nouvel onglet)"
+                className="text-neutral-700 underline underline-offset-2 hover:text-neutral-900"
+              >
+                CNIL
+              </a>
+              {' '}(Commission Nationale de l'Informatique et des Libertés).
+            </p>
+          </div>
+        </section>
+
+        <section aria-labelledby="securite-heading">
+          <h2 id="securite-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+            Sécurité
+          </h2>
+          <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600">
+            <p>
+              Ce site est servi exclusivement en HTTPS. Les données transmises via le formulaire d'inscription sont
+              chiffrées en transit. La sécurité des données est assurée par Netlify (hébergeur) et MailerLite (gestionnaire de la liste).
+            </p>
+          </div>
+        </section>
+
+        <section aria-labelledby="modifications-heading">
+          <h2 id="modifications-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+            Modifications de cette politique
+          </h2>
+          <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600">
+            <p>
+              Cette politique de confidentialité peut être mise à jour à tout moment. La date de dernière mise à jour
+              est indiquée en haut de cette page. En cas de modification substantielle, les abonnés à la newsletter seront informés par e-mail.
+            </p>
+          </div>
+        </section>
+
+        <div className="border-t border-neutral-200 pt-6">
+          <p className="text-xs font-light text-neutral-400">
+            Voir aussi nos{' '}
+            <Link
+              to="/mentions-legales"
+              className="text-neutral-600 underline underline-offset-2 hover:text-neutral-900"
+            >
+              Mentions légales
+            </Link>
+            {' '}et notre{' '}
+            <Link
+              to="/accessibilite"
+              className="text-neutral-600 underline underline-offset-2 hover:text-neutral-900"
+            >
+              Déclaration d'accessibilité
+            </Link>.
+          </p>
+        </div>
+
+      </div>
+    </Layout>
+  );
+}
+
+export const Head = ({ location }: { location: { pathname: string } }) => (
+  <SEO
+    title="Politique de Confidentialité — ART AU FÉMININ"
+    description="Politique de confidentialité du site ART AU FÉMININ : données collectées, utilisation de MailerLite pour la newsletter, vos droits RGPD et comment nous contacter."
+    url={`https://www.artaufeminin.fr${location.pathname}`}
+    noindex={true}
+  />
+);


### PR DESCRIPTION
## Résumé

- Création des pages légales `/mentions-legales`, `/politique-confidentialite` et `/accessibilite` (déclaration RGAA 4.1)
- Ajout d'une navigation "Liens légaux" en bas de footer
- Formulaire newsletter : `<label>` explicite + case à cocher de consentement opt-in RGPD obligatoire
- Correction `aria-label` sur le lien `aldjia.dev` dans le footer

## Ce qui change côté utilisateur

- Les visiteurs voient désormais les liens légaux en bas de chaque page
- L'inscription newsletter requiert un consentement explicite (case non cochée par défaut)
- Le bouton d'envoi est désactivé tant que la case n'est pas cochée

## Test

- [ ] Vérifier les 3 nouvelles pages (`/mentions-legales`, `/politique-confidentialite`, `/accessibilite`)
- [ ] Vérifier les liens légaux dans le footer
- [ ] Tester le formulaire newsletter : bouton désactivé sans consentement, inscription fonctionnelle avec consentement

🤖 Generated with [Claude Code](https://claude.com/claude-code)