### PR TITLE
fix(legal): corrige les apostrophes cassant la syntaxe JS

### DIFF
--- a/src/pages/accessibilite.tsx
+++ b/src/pages/accessibilite.tsx
@@ -54,16 +54,16 @@ export default function AccessibilitePage() {
           <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600">
             <ul className="space-y-2 pl-4">
               {[
-                'Langue de la page déclarée en français (lang="fr")',
-                'Lien d'évitement "Passer au contenu principal" en début de page',
-                'Structure de titres cohérente (h1, h2, h3) sur toutes les pages',
-                'Navigation clavier entièrement fonctionnelle avec focus visible',
-                'Attributs aria-label descriptifs sur tous les liens et boutons d'action',
-                'Alternatives textuelles sur toutes les images',
-                'Liens vers des ressources externes indiquant l'ouverture dans un nouvel onglet',
-                'Lecteurs d'écran : balises aria-hidden sur les éléments décoratifs',
-                'Points de repère ARIA (main, nav, footer) sur toutes les pages',
-                'Formulaire newsletter avec label explicite et indication des champs requis',
+                "Langue de la page déclarée en français (lang=\"fr\")",
+                "Lien d'évitement « Passer au contenu principal » en début de page",
+                "Structure de titres cohérente (h1, h2, h3) sur toutes les pages",
+                "Navigation clavier entièrement fonctionnelle avec focus visible",
+                "Attributs aria-label descriptifs sur tous les liens et boutons d'action",
+                "Alternatives textuelles sur toutes les images",
+                "Liens vers des ressources externes indiquant l'ouverture dans un nouvel onglet",
+                "Lecteurs d'écran : balises aria-hidden sur les éléments décoratifs",
+                "Points de repère ARIA (main, nav, footer) sur toutes les pages",
+                "Formulaire newsletter avec label explicite et indication des champs requis",
               ].map((measure) => (
                 <li key={measure} className="flex items-start gap-2">
                   <span className="mt-2 size-1 shrink-0 bg-neutral-400" />

--- a/src/pages/politique-confidentialite.tsx
+++ b/src/pages/politique-confidentialite.tsx
@@ -108,10 +108,10 @@ export default function PolitiqueConfidentialitePage() {
             <p>Conformément au RGPD, vous disposez des droits suivants :</p>
             <ul className="space-y-2 pl-4">
               {[
-                { droit: 'Droit d'accès', desc: 'obtenir une copie des données vous concernant.' },
+                { droit: "Droit d'accès", desc: 'obtenir une copie des données vous concernant.' },
                 { droit: 'Droit de rectification', desc: 'faire corriger vos données si elles sont inexactes.' },
-                { droit: 'Droit à l'effacement', desc: 'demander la suppression de vos données.' },
-                { droit: 'Droit d'opposition', desc: 'vous opposer au traitement de vos données.' },
+                { droit: "Droit à l'effacement", desc: 'demander la suppression de vos données.' },
+                { droit: "Droit d'opposition", desc: 'vous opposer au traitement de vos données.' },
                 { droit: 'Droit à la portabilité', desc: 'recevoir vos données dans un format structuré.' },
                 { droit: 'Droit de retrait du consentement', desc: 'en vous désinscrivant à tout moment via le lien en bas de chaque e-mail.' },
               ].map(({ droit, desc }) => (


### PR DESCRIPTION
## Problème

Les strings JS dans `accessibilite.tsx` et `politique-confidentialite.tsx` utilisaient des guillemets simples (`'`) avec des apostrophes françaises à l'intérieur, ce qui cassait la syntaxe et empêchait le build de démarrer.

## Correction

Remplacement des strings problématiques par des guillemets doubles (`"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)