### PR TITLE
fix(deps): ajoute .npmrc pour npm sur Netlify

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
Ajoute `legacy-peer-deps=true` dans `.npmrc` pour que `npm install` réussisse sur Netlify sans flag supplémentaire.