### PR TITLE
fix(netlify): node 22 + mentions légales images tierces

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,4 +3,4 @@
   publish = "public"
 
 [build.environment]
-  NODE_VERSION = "20"
+  NODE_VERSION = "22"

--- a/src/pages/mentions-legales.tsx
+++ b/src/pages/mentions-legales.tsx
@@ -15,21 +15,34 @@ export default function MentionsLegalesPage() {
           Mentions Légales
         </h1>
         <p className="mt-4 text-xs font-light text-neutral-400">
-          Conformément à la loi n° 2004-575 du 21 juin 2004 pour la confiance dans l'économie numérique (LCEN).
+          Conformément à la loi n° 2004-575 du 21 juin 2004 pour la confiance
+          dans l'économie numérique (LCEN).
         </p>
       </section>
 
       <div className="m-auto mb-20 w-3/4 max-w-3xl space-y-10">
-
         <section aria-labelledby="editeur-heading">
-          <h2 id="editeur-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+          <h2
+            id="editeur-heading"
+            className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900"
+          >
             Éditeur du site
           </h2>
           <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600 space-y-2">
-            <p><strong className="font-medium text-neutral-800">Nom :</strong> Aldjia Boughias</p>
-            <p><strong className="font-medium text-neutral-800">Qualité :</strong> Particulier — créatrice du podcast et du site ART AU FÉMININ</p>
             <p>
-              <strong className="font-medium text-neutral-800">Contact :</strong>{' '}
+              <strong className="font-medium text-neutral-800">Nom :</strong>{' '}
+              Aldjia Boughias
+            </p>
+            <p>
+              <strong className="font-medium text-neutral-800">
+                Qualité :
+              </strong>{' '}
+              Particulier — créatrice du podcast et du site ART AU FÉMININ
+            </p>
+            <p>
+              <strong className="font-medium text-neutral-800">
+                Contact :
+              </strong>{' '}
               <a
                 href="mailto:artaufemininlepodcast@gmail.com"
                 className="text-neutral-700 underline underline-offset-2 hover:text-neutral-900"
@@ -41,12 +54,26 @@ export default function MentionsLegalesPage() {
         </section>
 
         <section aria-labelledby="hebergeur-heading">
-          <h2 id="hebergeur-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+          <h2
+            id="hebergeur-heading"
+            className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900"
+          >
             Hébergeur
           </h2>
           <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600 space-y-2">
-            <p><strong className="font-medium text-neutral-800">Société :</strong> Netlify, Inc.</p>
-            <p><strong className="font-medium text-neutral-800">Adresse :</strong> 44 Montgomery Street, Suite 300, San Francisco, California 94104, États-Unis</p>
+            <p>
+              <strong className="font-medium text-neutral-800">
+                Société :
+              </strong>{' '}
+              Netlify, Inc.
+            </p>
+            <p>
+              <strong className="font-medium text-neutral-800">
+                Adresse :
+              </strong>{' '}
+              44 Montgomery Street, Suite 300, San Francisco, California 94104,
+              États-Unis
+            </p>
             <p>
               <strong className="font-medium text-neutral-800">Site :</strong>{' '}
               <a
@@ -63,77 +90,113 @@ export default function MentionsLegalesPage() {
         </section>
 
         <section aria-labelledby="propriete-heading">
-          <h2 id="propriete-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+          <h2
+            id="propriete-heading"
+            className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900"
+          >
             Propriété intellectuelle
           </h2>
           <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600 space-y-3">
             <p>
-              L'ensemble du contenu de ce site (textes, images, sons, podcasts, logos, graphismes) est la propriété exclusive
-              d'Aldjia Boughias, sauf mention contraire explicite.
+              Les textes, podcasts, logos et graphismes créés pour ce site sont
+              la propriété d'Aldjia Boughias, sauf mention contraire explicite.
             </p>
             <p>
-              Toute reproduction, représentation, modification, publication ou adaptation de tout ou partie des éléments du site,
-              quel que soit le moyen ou le procédé utilisé, est interdite sans autorisation préalable écrite.
+              Les images reproduites sur ce site (œuvres d'art, photographies
+              d'artistes, visuels d'expositions) sont la propriété de leurs
+              auteurs et ayants droit respectifs. Elles sont utilisées à des
+              fins d'illustration culturelle et éducative, avec indication de
+              leur source lorsque celle-ci est connue. Si vous êtes titulaire de
+              droits sur une image et souhaitez qu'elle soit retirée ou créditée
+              différemment, contactez-nous à{' '}
+              <a
+                href="mailto:artaufemininlepodcast@gmail.com"
+                className="text-neutral-700 underline underline-offset-2 hover:text-neutral-900"
+              >
+                artaufemininlepodcast@gmail.com
+              </a>
+              .
             </p>
             <p>
-              Toute exploitation non autorisée du site ou de l'un quelconque des éléments qu'il contient sera considérée
-              comme constitutive d'une contrefaçon et poursuivie conformément aux dispositions des articles L.335-2 et suivants
-              du Code de Propriété Intellectuelle.
+              Toute reproduction, représentation, modification, publication ou
+              adaptation des contenus propres à ce site, quel que soit le moyen
+              ou le procédé utilisé, est interdite sans autorisation préalable
+              écrite.
+            </p>
+            <p>
+              Toute exploitation non autorisée sera considérée comme
+              constitutive d'une contrefaçon et poursuivie conformément aux
+              dispositions des articles L.335-2 et suivants du Code de Propriété
+              Intellectuelle.
             </p>
           </div>
         </section>
 
         <section aria-labelledby="responsabilite-heading">
-          <h2 id="responsabilite-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+          <h2
+            id="responsabilite-heading"
+            className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900"
+          >
             Limitation de responsabilité
           </h2>
           <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600 space-y-3">
             <p>
-              L'éditeur s'efforce de fournir sur ce site des informations aussi précises que possible. Toutefois, il ne
-              pourra être tenu responsable des omissions, inexactitudes et carences dans la mise à jour, qu'elles soient
-              de son fait ou du fait des tiers partenaires qui lui fournissent ces informations.
+              L'éditeur s'efforce de fournir sur ce site des informations aussi
+              précises que possible. Toutefois, il ne pourra être tenu
+              responsable des omissions, inexactitudes et carences dans la mise
+              à jour, qu'elles soient de son fait ou du fait des tiers
+              partenaires qui lui fournissent ces informations.
             </p>
             <p>
-              Les informations présentes sur ce site sont non contractuelles et peuvent être modifiées à tout moment.
-              L'accès au site peut être interrompu à tout moment sans préavis.
+              Les informations présentes sur ce site sont non contractuelles et
+              peuvent être modifiées à tout moment. L'accès au site peut être
+              interrompu à tout moment sans préavis.
             </p>
           </div>
         </section>
 
         <section aria-labelledby="cookies-heading">
-          <h2 id="cookies-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+          <h2
+            id="cookies-heading"
+            className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900"
+          >
             Cookies
           </h2>
           <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600 space-y-3">
             <p>
-              Ce site ne dépose pas de cookies de pistage ou de publicité. Le service de newsletter (MailerLite) peut
-              utiliser des cookies fonctionnels lors de la confirmation d'inscription. Aucun outil d'analyse comportementale
-              tiers n'est activé sur ce site.
+              Ce site ne dépose pas de cookies de pistage ou de publicité. Le
+              service de newsletter (MailerLite) peut utiliser des cookies
+              fonctionnels lors de la confirmation d'inscription. Aucun outil
+              d'analyse comportementale tiers n'est activé sur ce site.
             </p>
             <p>
-              Pour en savoir plus sur la gestion de vos données personnelles, consultez notre{' '}
+              Pour en savoir plus sur la gestion de vos données personnelles,
+              consultez notre{' '}
               <Link
                 to="/politique-confidentialite"
                 className="text-neutral-700 underline underline-offset-2 hover:text-neutral-900"
               >
                 Politique de confidentialité
-              </Link>.
+              </Link>
+              .
             </p>
           </div>
         </section>
 
         <section aria-labelledby="droit-applicable-heading">
-          <h2 id="droit-applicable-heading" className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+          <h2
+            id="droit-applicable-heading"
+            className="mb-4 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900"
+          >
             Droit applicable
           </h2>
           <div className="border border-neutral-200 p-6 text-sm font-light leading-relaxed text-neutral-600">
             <p>
-              Les présentes mentions légales sont soumises au droit français. En cas de litige, les tribunaux français
-              seront seuls compétents.
+              Les présentes mentions légales sont soumises au droit français. En
+              cas de litige, les tribunaux français seront seuls compétents.
             </p>
           </div>
         </section>
-
       </div>
     </Layout>
   );


### PR DESCRIPTION
## Corrections

**Netlify :** aligne `NODE_VERSION` sur `22` — Netlify utilisait déjà Node 22 en ignorant la valeur `20`, ce qui pouvait créer des incohérences.

**Mentions légales :** la section propriété intellectuelle indiquait à tort que toutes les images appartenaient à Aldjia Boughias. Corrigé pour distinguer :
- Textes, podcasts, logos = propriété d'Aldjia Boughias
- Images (œuvres, photos d'artistes) = propriété de leurs auteurs respectifs, avec contact pour demande de retrait

🤖 Generated with [Claude Code](https://claude.com/claude-code)