### PR TITLE
perf: optimise LCP mobile — fetchpriority, lazy loading, fonts non-bloquantes

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,9 +1,16 @@
-import React from "react"
-import "./src/stylesheets/global.css"
-import "typeface-merriweather"
+import React from 'react';
+import './src/stylesheets/global.css';
 
-import { AudioProvider } from "./src/components/player/AudioProvider"
+import { AudioProvider } from './src/components/player/AudioProvider';
 
 export const wrapRootElement = ({ element }) => (
   <AudioProvider>{element}</AudioProvider>
-)
+);
+
+export const onClientEntry = () => {
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href =
+    'https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400;1,600&display=swap';
+  document.head.appendChild(link);
+};

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,9 +1,9 @@
-import React from "react"
-import { AudioProvider } from "./src/components/player/AudioProvider"
+import React from 'react';
+import { AudioProvider } from './src/components/player/AudioProvider';
 
 export const wrapRootElement = ({ element }) => (
   <AudioProvider>{element}</AudioProvider>
-)
+);
 
 export const onRenderBody = ({ setHtmlAttributes, setHeadComponents }) => {
   setHtmlAttributes({ lang: 'fr' });
@@ -22,8 +22,9 @@ export const onRenderBody = ({ setHtmlAttributes, setHeadComponents }) => {
     />,
     <link
       key="gf-cormorant"
-      rel="stylesheet"
+      rel="preload"
+      as="style"
       href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400;1,600&display=swap"
     />,
-  ])
-}
+  ]);
+};

--- a/src/components/content-card.tsx
+++ b/src/components/content-card.tsx
@@ -22,11 +22,19 @@ export function ContentCard({
 }: ContentCardProps) {
   return (
     <article className="group flex flex-col">
-      <Link to={href} tabIndex={-1} aria-hidden="true" className="block overflow-hidden bg-neutral-100">
+      <Link
+        to={href}
+        tabIndex={-1}
+        aria-hidden="true"
+        className="block overflow-hidden bg-neutral-100"
+      >
         <div className="aspect-square overflow-hidden">
           <img
             src={imageUrl}
             alt={imageAlt}
+            width={400}
+            height={400}
+            loading="lazy"
             className="h-full w-full object-cover object-center transition-transform duration-700 group-hover:scale-[1.04]"
           />
         </div>
@@ -47,9 +55,7 @@ export function ContentCard({
           {description}
         </p>
 
-        <div className="mt-4">
-          {action}
-        </div>
+        <div className="mt-4">{action}</div>
       </div>
     </article>
   );

--- a/src/components/featured-card.tsx
+++ b/src/components/featured-card.tsx
@@ -23,10 +23,18 @@ export function FeaturedCard({
   imageRight = false,
 }: FeaturedCardProps) {
   const image = (
-    <Link to={href} tabIndex={-1} aria-hidden="true" className="block overflow-hidden bg-neutral-100">
+    <Link
+      to={href}
+      tabIndex={-1}
+      aria-hidden="true"
+      className="block overflow-hidden bg-neutral-100"
+    >
       <img
         src={imageUrl}
         alt={imageAlt}
+        width={800}
+        height={450}
+        loading="lazy"
         className="h-full w-full object-cover object-top transition-transform duration-700 ease-out group-hover:scale-[1.02]"
         style={{ aspectRatio: '16/9', minHeight: 320 }}
       />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,7 +10,6 @@ import { stripHtml } from '../utils/html';
 
 import heroImage from '../images/instagram/votre-image.jpg';
 
-
 /* ─── Page ──────────────────────────────────────────────────────── */
 const IndexPage = ({ data }) => {
   const allEpisodes = data.allAnchorEpisode.nodes;
@@ -19,11 +18,11 @@ const IndexPage = ({ data }) => {
 
   return (
     <Layout withInstagram={false}>
-
       {/* ── HERO — image plein cadre + strip "Now Open" ─────────── */}
       <section className="-mx-4" aria-labelledby="hero-heading">
         <h1 id="hero-heading" className="sr-only">
-          ART AU FÉMININ — Le podcast sur les femmes artistes et l'Histoire de l'Art
+          ART AU FÉMININ — Le podcast sur les femmes artistes et l'Histoire de
+          l'Art
         </h1>
 
         {/* Image pleine hauteur */}
@@ -35,6 +34,8 @@ const IndexPage = ({ data }) => {
             src={heroImage}
             alt="ART AU FÉMININ"
             className="h-full w-full object-cover object-[center_30%]"
+            fetchpriority="high"
+            loading="eager"
           />
           {/* Gradient + phrase d'accroche */}
           <div className="absolute inset-0 bg-black/40" />
@@ -47,7 +48,8 @@ const IndexPage = ({ data }) => {
               <span className="italic">l'Histoire les a oubliées.</span>
             </h2>
             <p className="mt-6 max-w-lg text-base font-light leading-relaxed text-white/60">
-              Un podcast pour redécouvrir les femmes artistes qui ont façonné l'Art — de l'Antiquité à aujourd'hui.
+              Un podcast pour redécouvrir les femmes artistes qui ont façonné
+              l'Art — de l'Antiquité à aujourd'hui.
             </p>
           </div>
         </div>
@@ -64,7 +66,8 @@ const IndexPage = ({ data }) => {
                 {latestEpisode.title}
               </span>
               <span className="hidden shrink-0 text-xs font-light text-neutral-400 sm:block">
-                Saison {latestEpisode.itunes.season} · Épisode {latestEpisode.itunes.episode}
+                Saison {latestEpisode.itunes.season} · Épisode{' '}
+                {latestEpisode.itunes.episode}
               </span>
               <Link
                 to={`/podcasts/${latestEpisode.guid}`}
@@ -79,11 +82,16 @@ const IndexPage = ({ data }) => {
       </section>
 
       {/* ── ÉPISODES ─────────────────────────────────────────────── */}
-      <section className="mx-auto mt-16 w-11/12 max-w-7xl" aria-labelledby="section-episodes">
-
+      <section
+        className="mx-auto mt-16 w-11/12 max-w-7xl"
+        aria-labelledby="section-episodes"
+      >
         {/* En-tête de section */}
         <div className="mb-10 flex items-baseline justify-between border-b border-neutral-200 pb-4">
-          <h2 id="section-episodes" className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+          <h2
+            id="section-episodes"
+            className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900"
+          >
             Épisodes
           </h2>
           <Link
@@ -105,7 +113,8 @@ const IndexPage = ({ data }) => {
             title={allEpisodes[0].title}
             description={
               allEpisodes[0].itunes.summary
-                ? stripHtml(allEpisodes[0].itunes.summary).substring(0, 240) + '…'
+                ? stripHtml(allEpisodes[0].itunes.summary).substring(0, 240) +
+                  '…'
                 : undefined
             }
             cta={
@@ -155,10 +164,15 @@ const IndexPage = ({ data }) => {
       <div className="mx-auto my-20 w-11/12 max-w-7xl border-t border-neutral-200" />
 
       {/* ── ARTICLES ─────────────────────────────────────────────── */}
-      <section className="mx-auto w-11/12 max-w-7xl" aria-labelledby="section-articles">
-
+      <section
+        className="mx-auto w-11/12 max-w-7xl"
+        aria-labelledby="section-articles"
+      >
         <div className="mb-10 flex items-baseline justify-between border-b border-neutral-200 pb-4">
-          <h2 id="section-articles" className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
+          <h2
+            id="section-articles"
+            className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900"
+          >
             Articles
           </h2>
           <Link
@@ -171,33 +185,36 @@ const IndexPage = ({ data }) => {
         </div>
 
         {/* Grande card featured — dernier article */}
-        {allArticles[0] && (() => {
-          const art = allArticles[0];
-          const title = RichText.asText(art.data.title.richText);
-          const description = art.data.description?.richText
-            ? RichText.asText(art.data.description.richText)
-            : undefined;
-          return (
-            <FeaturedCard
-              href={`/articles/${art.uid}`}
-              imageUrl={art.data.image.url}
-              imageAlt={art.data.image.alt || title}
-              label="Article · À la Une"
-              title={title}
-              description={description ? description.substring(0, 240) + '…' : undefined}
-              imageRight
-              cta={
-                <Link
-                  to={`/articles/${art.uid}`}
-                  aria-label={`Lire l'article : ${title}`}
-                  className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors hover:text-neutral-900"
-                >
-                  Lire l'Article <span aria-hidden="true">→</span>
-                </Link>
-              }
-            />
-          );
-        })()}
+        {allArticles[0] &&
+          (() => {
+            const art = allArticles[0];
+            const title = RichText.asText(art.data.title.richText);
+            const description = art.data.description?.richText
+              ? RichText.asText(art.data.description.richText)
+              : undefined;
+            return (
+              <FeaturedCard
+                href={`/articles/${art.uid}`}
+                imageUrl={art.data.image.url}
+                imageAlt={art.data.image.alt || title}
+                label="Article · À la Une"
+                title={title}
+                description={
+                  description ? description.substring(0, 240) + '…' : undefined
+                }
+                imageRight
+                cta={
+                  <Link
+                    to={`/articles/${art.uid}`}
+                    aria-label={`Lire l'article : ${title}`}
+                    className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors hover:text-neutral-900"
+                  >
+                    Lire l'Article <span aria-hidden="true">→</span>
+                  </Link>
+                }
+              />
+            );
+          })()}
 
         {/* Grille des articles suivants */}
         {allArticles.length > 1 && (
@@ -205,7 +222,10 @@ const IndexPage = ({ data }) => {
             {allArticles.slice(1).map((article: any) => {
               const title = RichText.asText(article.data.title.richText);
               const description = article.data.description?.richText
-                ? RichText.asText(article.data.description.richText).substring(0, 120) + '…'
+                ? RichText.asText(article.data.description.richText).substring(
+                    0,
+                    120
+                  ) + '…'
                 : '';
               return (
                 <ContentCard
@@ -246,9 +266,10 @@ const IndexPage = ({ data }) => {
               « Sororité »
             </p>
             <p className="mt-5 text-sm font-light leading-relaxed text-white/50">
-              Une galerie d'Art immersive en 3D dédiée aux femmes artistes.
-              La première exposition réunit une vingtaine d'artistes autour du thème
-              de la Sororité — ce lien puissant entre femmes qui traverse l'Histoire de l'Art.
+              Une galerie d'Art immersive en 3D dédiée aux femmes artistes. La
+              première exposition réunit une vingtaine d'artistes autour du
+              thème de la Sororité — ce lien puissant entre femmes qui traverse
+              l'Histoire de l'Art.
             </p>
           </div>
           <a
@@ -280,7 +301,6 @@ const IndexPage = ({ data }) => {
           </a>
         </div>
       </section>
-
     </Layout>
   );
 };
@@ -308,8 +328,12 @@ export const indexPageQuery = graphql`
     uid
     data {
       date
-      title { richText }
-      description { richText }
+      title {
+        richText
+      }
+      description {
+        richText
+      }
       image {
         alt
         copyright


### PR DESCRIPTION
## Problème

PageSpeed Insights signalait :
- **LCP mobile : 33,9s** (objectif < 4s)
- **Score performances mobile : 69**

Trois causes identifiées et corrigées.

## Corrections

### 1. Image hero — `fetchpriority=high` (`src/pages/index.tsx`)
L'image LCP n'avait pas de signal de priorité pour le navigateur. Ajout de `fetchpriority="high"` et `loading="eager"` pour déclencher le téléchargement immédiatement.

### 2. Images podcast Cloudfront — lazy loading (`content-card.tsx`, `featured-card.tsx`)
Les images Ausha (3000×3000px) étaient toutes téléchargées au chargement initial, même hors écran (~5,4 Mo). Ajout de `loading="lazy"` et de dimensions explicites (`width`/`height`) sur les deux composants cards.

### 3. Google Fonts — chargement non-bloquant (`gatsby-ssr.js`, `gatsby-browser.js`)
- Cormorant Garamond passée de `rel="stylesheet"` (bloquant) à `rel="preload" as="style"` + application via `onClientEntry` (non-bloquant)
- Suppression de `import "typeface-merriweather"` : police inutilisée depuis la refonte, responsable du second appel font bloquant signalé par PageSpeed

## Résultat attendu
- LCP mobile : 33,9s → objectif < 4s
- Score performances mobile : 69 → objectif 85+

🤖 Generated with [Claude Code](https://claude.com/claude-code)