### PR TITLE
perf: supprime gatsby-plugin-google-fonts bloquant (750ms)

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -11,6 +11,6 @@ export const onClientEntry = () => {
   const link = document.createElement('link');
   link.rel = 'stylesheet';
   link.href =
-    'https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400;1,600&display=swap';
+    'https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400;1,600&family=Inter:wght@300;400;500&display=swap';
   document.head.appendChild(link);
 };

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,23 +1,13 @@
-const siteConfig = require("./siteConfig")
+const siteConfig = require('./siteConfig');
 
-const { linkResolver } = require("./src/utils/linkResolver.ts")
-const siteUrl = process.env.URL || siteConfig.siteUrl
+const { linkResolver } = require('./src/utils/linkResolver.ts');
+const siteUrl = process.env.URL || siteConfig.siteUrl;
 module.exports = {
   siteMetadata: {
     ...siteConfig,
   },
   plugins: [
     `gatsby-plugin-postcss`,
-    {
-      resolve: "gatsby-plugin-google-fonts",
-      options: {
-        fonts: [
-          "Cormorant Garamond:300,300i,400,400i,500",
-          "Inter:300,400,500",
-        ],
-        display: 'swap',
-      },
-    },
     {
       resolve: `gatsby-source-filesystem`,
       options: {
@@ -47,7 +37,7 @@ module.exports = {
       },
     },
     {
-      resolve: "gatsby-plugin-sitemap",
+      resolve: 'gatsby-plugin-sitemap',
       options: {
         output: `/`,
         query: `
@@ -61,7 +51,7 @@ module.exports = {
       `,
         resolveSiteUrl: () => siteUrl,
         resolvePages: ({ allSitePage: { nodes: allPages } }) => {
-          return allPages.map((page) => ({ ...page }))
+          return allPages.map((page) => ({ ...page }));
         },
         serialize: ({ path }) => ({
           url: `${siteUrl}${path}`,
@@ -77,18 +67,18 @@ module.exports = {
       },
     },
     {
-      resolve: "gatsby-source-prismic",
+      resolve: 'gatsby-source-prismic',
       options: {
-        repositoryName: "artaufeminin",
+        repositoryName: 'artaufeminin',
         linkResolver: (doc) => linkResolver(doc),
         schemas: {
-          faq: require("./custom_types/faq.json"),
-          blog_post: require("./custom_types/blog_post.json"),
-          press: require("./custom_types/press.json"),
-          quotation: require("./custom_types/quotation.json"),
-          book_review: require("./custom_types/book_review.json"),
+          faq: require('./custom_types/faq.json'),
+          blog_post: require('./custom_types/blog_post.json'),
+          press: require('./custom_types/press.json'),
+          quotation: require('./custom_types/quotation.json'),
+          book_review: require('./custom_types/book_review.json'),
         },
       },
     },
   ],
-}
+};

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -24,7 +24,7 @@ export const onRenderBody = ({ setHtmlAttributes, setHeadComponents }) => {
       key="gf-cormorant"
       rel="preload"
       as="style"
-      href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400;1,600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400;1,600&family=Inter:wght@300;400;500&display=swap"
     />,
   ]);
 };


### PR DESCRIPTION
## Problème

PageSpeed signalait encore 1 appel Google Fonts bloquant sur mobile :
- `/css?family=Cormorant+Garamond&Inter` — **750ms bloquants**

Source identifiée : `gatsby-plugin-google-fonts` dans `gatsby-config.js`, qui génère un `<link rel="stylesheet">` vers l'ancienne API Google Fonts (`/css?family=`).

## Corrections

### `gatsby-config.js`
Suppression complète du plugin `gatsby-plugin-google-fonts`.

### `gatsby-ssr.js` + `gatsby-browser.js`
Ajout d'Inter à l'URL combinée existante (non-bloquante) :
```
css2?family=Cormorant+Garamond:...&family=Inter:wght@300;400;500&display=swap
```
Une seule requête non-bloquante pour les deux polices (preload SSR + application via `onClientEntry`).

## Résultat attendu
- Requêtes Google Fonts bloquantes : 750ms → 0ms
- Score performances mobile : 85 → 90+

🤖 Generated with [Claude Code](https://claude.com/claude-code)