### PR TITLE
SEO : migration URLs podcast UUID -> slugs lisibles

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -7,6 +7,7 @@ module.exports = {
     ...siteConfig,
   },
   plugins: [
+    `gatsby-plugin-netlify`,
     `gatsby-plugin-postcss`,
     {
       resolve: `gatsby-source-filesystem`,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,62 +1,82 @@
-// Controlling your site’s data in the GraphQL data layer.
+// Controlling your site's data in the GraphQL data layer.
 // https://www.gatsbyjs.com/docs/reference/config-files/gatsby-node/
 
-const path = require(`path`)
+const path = require(`path`);
+
+const slugify = (text) =>
+  text
+    .toString()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
 
 // Log out information after a build is done
 exports.onPostBuild = ({ reporter }) => {
-  reporter.info(`✅ Your Gatsby site has been built`)
-}
+  reporter.info(`✅ Your Gatsby site has been built`);
+};
 
-const FIRST_PAGE_LIMIT = 10
-const OTHER_PAGES_LIMIT = 12
+const FIRST_PAGE_LIMIT = 10;
+const OTHER_PAGES_LIMIT = 12;
 
 function buildPaginatedPages(total) {
-  const remaining = Math.max(0, total - FIRST_PAGE_LIMIT)
-  const numPages = 1 + Math.ceil(remaining / OTHER_PAGES_LIMIT)
+  const remaining = Math.max(0, total - FIRST_PAGE_LIMIT);
+  const numPages = 1 + Math.ceil(remaining / OTHER_PAGES_LIMIT);
   return Array.from({ length: numPages }).map((_, i) => ({
     currentPage: i + 1,
     numPages,
     limit: i === 0 ? FIRST_PAGE_LIMIT : OTHER_PAGES_LIMIT,
     skip: i === 0 ? 0 : FIRST_PAGE_LIMIT + (i - 1) * OTHER_PAGES_LIMIT,
-  }))
+  }));
 }
 
 // Create blog pages dynamically
 exports.createPages = async ({ graphql, actions }) => {
-  const { createPage, createRedirect } = actions
+  const { createPage, createRedirect } = actions;
 
   // ── ARTICLES LIST (paginée) ──────────────────────────────────────
-  const articlesListTemplate = path.resolve(`src/templates/articles-list.tsx`)
+  const articlesListTemplate = path.resolve(`src/templates/articles-list.tsx`);
   const articlesCount = await graphql(`
-    query { allPrismicBlogPost { totalCount } }
-  `)
+    query {
+      allPrismicBlogPost {
+        totalCount
+      }
+    }
+  `);
   buildPaginatedPages(articlesCount.data.allPrismicBlogPost.totalCount).forEach(
     ({ currentPage, numPages, limit, skip }) => {
       createPage({
         path: currentPage === 1 ? `/articles/` : `/articles/${currentPage}/`,
         component: articlesListTemplate,
         context: { limit, skip, currentPage, numPages },
-      })
+      });
     }
-  )
+  );
 
   // ── PODCASTS LIST (paginée) ──────────────────────────────────────
-  const podcastsListTemplate = path.resolve(`src/templates/podcasts-list.tsx`)
+  const podcastsListTemplate = path.resolve(`src/templates/podcasts-list.tsx`);
   const podcastsCount = await graphql(`
-    query { allAnchorEpisode { totalCount } }
-  `)
+    query {
+      allAnchorEpisode {
+        totalCount
+      }
+    }
+  `);
   buildPaginatedPages(podcastsCount.data.allAnchorEpisode.totalCount).forEach(
     ({ currentPage, numPages, limit, skip }) => {
       createPage({
         path: currentPage === 1 ? `/podcasts/` : `/podcasts/${currentPage}/`,
         component: podcastsListTemplate,
         context: { limit, skip, currentPage, numPages },
-      })
+      });
     }
-  )
+  );
 
-  const episodeTemplate = path.resolve(`src/templates/episode.tsx`)
+  const episodeTemplate = path.resolve(`src/templates/episode.tsx`);
   const podcats = await graphql(`
     query {
       allAnchorEpisode {
@@ -78,25 +98,37 @@ exports.createPages = async ({ graphql, actions }) => {
         }
       }
     }
-  `)
+  `);
   podcats.data.allAnchorEpisode.nodes.forEach((node) => {
-    // Redirect old url to new url needs to be before `createPage`
+    const slug = slugify(node.title);
+    const newPath = `podcasts/${slug}/`;
+    const oldPath = `podcasts/${node.guid}/`;
+
+    // Redirect ancienne URL UUID → nouvelle URL slug (301)
+    createRedirect({
+      fromPath: `/${oldPath}`,
+      toPath: `/${newPath}`,
+      isPermanent: true,
+    });
+
+    // Redirect encore plus ancienne URL /podcast/ → nouvelle URL slug (301)
     createRedirect({
       fromPath: `/podcast/${node.guid}`,
-      toPath: `/podcasts/${node.guid}`,
+      toPath: `/${newPath}`,
       isPermanent: true,
-    })
+    });
 
     createPage({
-      path: `podcasts/${node.guid}`,
+      path: newPath,
       component: episodeTemplate,
       context: {
         ...node,
+        slug,
       },
-    })
-  })
+    });
+  });
 
-  const articleTemplate = path.resolve(`src/templates/article.tsx`)
+  const articleTemplate = path.resolve(`src/templates/article.tsx`);
   const articles = await graphql(`
     query {
       allPrismicBlogPost {
@@ -147,7 +179,7 @@ exports.createPages = async ({ graphql, actions }) => {
         }
       }
     }
-  `)
+  `);
 
   articles.data.allPrismicBlogPost.edges.forEach((edge) => {
     // Redirect old url to new url needs to be before `createPage`
@@ -155,7 +187,7 @@ exports.createPages = async ({ graphql, actions }) => {
       fromPath: `/article/${edge.node.uid}`,
       toPath: `/articles/${edge.node.uid}`,
       isPermanent: true,
-    })
+    });
 
     createPage({
       path: `articles/${edge.node.uid}`,
@@ -163,10 +195,10 @@ exports.createPages = async ({ graphql, actions }) => {
       context: {
         ...edge,
       },
-    })
-  })
+    });
+  });
 
-  const bookTemplate = path.resolve(`src/templates/book.tsx`)
+  const bookTemplate = path.resolve(`src/templates/book.tsx`);
   const books = await graphql(`
     query {
       allPrismicBookReview {
@@ -186,7 +218,7 @@ exports.createPages = async ({ graphql, actions }) => {
         }
       }
     }
-  `)
+  `);
 
   books.data.allPrismicBookReview.edges.forEach((edge) => {
     // Redirect old url to new url needs to be before `createPage`
@@ -194,7 +226,7 @@ exports.createPages = async ({ graphql, actions }) => {
       fromPath: `/livre/${edge.node.uid}`,
       toPath: `/livres/${edge.node.uid}`,
       isPermanent: true,
-    })
+    });
 
     createPage({
       path: `livres/${edge.node.uid}`,
@@ -202,6 +234,6 @@ exports.createPages = async ({ graphql, actions }) => {
       context: {
         ...edge,
       },
-    })
-  })
-}
+    });
+  });
+};

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "gatsby-plugin-google-fonts": "^1.0.1",
     "gatsby-plugin-image": "^3.14.0",
     "gatsby-plugin-manifest": "^5.14.0",
+    "gatsby-plugin-netlify": "^5.1.1",
     "gatsby-plugin-postcss": "^6.14.0",
     "gatsby-plugin-react-helmet": "^6.14.0",
     "gatsby-plugin-sharp": "^5.14.0",

--- a/src/components/episodeItem.tsx
+++ b/src/components/episodeItem.tsx
@@ -1,6 +1,8 @@
 import { Link } from 'gatsby';
 import React, { useMemo } from 'react';
 
+import { slugify } from '../utils/slugify';
+
 import { useAudioPlayer } from './player/AudioProvider';
 import { PlayButton } from './player/PlayButton';
 import { stripHtml } from '../utils/html';
@@ -37,9 +39,9 @@ export default function EpisodeItem({
         src: episode.enclosure.url,
         type: 'audio/mpeg',
       },
-      link: `/${episode.guid}`,
+      link: `/podcasts/${slugify(episode.title)}/`,
     }),
-    [episode],
+    [episode]
   );
   const player = useAudioPlayer(audioPlayerData);
 
@@ -51,7 +53,7 @@ export default function EpisodeItem({
   return (
     <>
       <Link
-        to={`/podcasts/${episode.guid}`}
+        to={`/podcasts/${slugify(episode.title)}/`}
         className="article-preview flex flex-col hover:no-underline md:flex-row"
       >
         <div className="flex-1">
@@ -74,7 +76,9 @@ export default function EpisodeItem({
       </Link>
       <div className="flex items-center">
         <PlayButton player={player} size="small" />
-        <Text className="ml-4 text-sm font-semibold uppercase tracking-widest text-clay-500">Écouter</Text>
+        <Text className="ml-4 text-sm font-semibold uppercase tracking-widest text-clay-500">
+          Écouter
+        </Text>
       </div>
       <hr className="separator my-8" />
     </>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import HeroCard from './heroCard';
+import { slugify } from '../utils/slugify';
 
 type HeroProps = {
   allEpisodes: any;
@@ -23,7 +24,7 @@ export function Hero({ allEpisodes }: HeroProps) {
         {allEpisodes.slice(0, 3).map((episode: any) => (
           <HeroCard
             key={episode.guid}
-            heroLink={`/podcasts/${episode.guid}`}
+            heroLink={`/podcasts/${slugify(episode.title)}/`}
             imageUrl={episode.itunes.image}
             heroTitle={episode.title}
             subtitle={`Saison ${episode.itunes.season} · Épisode ${episode.itunes.episode}`}

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -8,6 +8,7 @@ import { AudioPlayer } from './player/AudioPlayer';
 import { useAudioPlayer } from './player/AudioProvider';
 import { PlayButton } from './player/PlayButton';
 import Text from './text';
+import { slugify } from '../utils/slugify';
 
 interface LayoutProps {
   children: ReactNode;
@@ -28,7 +29,6 @@ function Layout({
             url
           }
           title
-          guid
         }
       }
       site {
@@ -41,7 +41,6 @@ function Layout({
   const audioUrl = data.allAnchorEpisode.nodes[0].enclosure.url;
   const siteTitle = data.site.siteMetadata.title;
   const lastPodcastTitle = data.allAnchorEpisode.nodes[0].title;
-  const guid = data.allAnchorEpisode.nodes[0].guid;
 
   const audioPlayerData = useMemo(
     () => ({
@@ -50,9 +49,9 @@ function Layout({
         src: audioUrl,
         type: 'audio/mpeg',
       },
-      link: `/${guid}`,
+      link: `/podcasts/${slugify(lastPodcastTitle)}/`,
     }),
-    [audioUrl, guid, lastPodcastTitle],
+    [audioUrl, lastPodcastTitle]
   );
   const player = useAudioPlayer(audioPlayerData);
 

--- a/src/pages/_podcasts.tsx
+++ b/src/pages/_podcasts.tsx
@@ -3,6 +3,7 @@ import React, { useMemo } from 'react';
 
 import { FeaturedCard } from '../components/featured-card';
 import { stripHtml } from '../utils/html';
+import { slugify } from '../utils/slugify';
 import { ContentCard } from '../components/content-card';
 import Layout from '../components/layout';
 import SEO from '../components/seo';
@@ -14,9 +15,9 @@ function EpisodeCard({ episode }: { episode: any }) {
     () => ({
       title: episode.title,
       audio: { src: episode.enclosure.url, type: 'audio/mpeg' },
-      link: `/podcasts/${episode.guid}`,
+      link: `/podcasts/${slugify(episode.title)}/`,
     }),
-    [episode],
+    [episode]
   );
   const player = useAudioPlayer(audioPlayerData);
 
@@ -34,7 +35,7 @@ function EpisodeCard({ episode }: { episode: any }) {
 
   return (
     <ContentCard
-      href={`/podcasts/${episode.guid}`}
+      href={`/podcasts/${slugify(episode.title)}/`}
       imageUrl={episode.itunes.image}
       imageAlt={episode.title}
       meta={meta}
@@ -59,7 +60,6 @@ const PodcastsPage = ({ data }) => {
 
   return (
     <Layout>
-
       {/* ── EN-TÊTE ───────────────────────────────────────────────── */}
       <section className="mx-auto mb-10 mt-8 w-11/12 max-w-7xl border-b border-neutral-200 pb-8">
         <p className="mb-2 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
@@ -79,7 +79,7 @@ const PodcastsPage = ({ data }) => {
             </h2>
           </div>
           <FeaturedCard
-            href={`/podcasts/${featured.guid}`}
+            href={`/podcasts/${slugify(featured.title)}/`}
             imageUrl={featured.itunes.image}
             imageAlt={featured.title}
             label={`Saison ${featured.itunes.season} · Épisode ${featured.itunes.episode}`}
@@ -91,7 +91,7 @@ const PodcastsPage = ({ data }) => {
             }
             cta={
               <Link
-                to={`/podcasts/${featured.guid}`}
+                to={`/podcasts/${slugify(featured.title)}/`}
                 aria-label={`Écouter l'épisode : ${featured.title}`}
                 className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors hover:text-neutral-900"
               >
@@ -117,7 +117,6 @@ const PodcastsPage = ({ data }) => {
           </div>
         </section>
       )}
-
     </Layout>
   );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,6 +7,7 @@ import { FeaturedCard } from '../components/featured-card';
 import Layout from '../components/layout';
 import SEO from '../components/seo';
 import { stripHtml } from '../utils/html';
+import { slugify } from '../utils/slugify';
 
 import heroImage from '../images/instagram/votre-image.jpg';
 
@@ -70,7 +71,7 @@ const IndexPage = ({ data }) => {
                 {latestEpisode.itunes.episode}
               </span>
               <Link
-                to={`/podcasts/${latestEpisode.guid}`}
+                to={`/podcasts/${slugify(latestEpisode.title)}/`}
                 aria-label={`Écouter : ${latestEpisode.title}`}
                 className="shrink-0 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors hover:text-neutral-900"
               >
@@ -106,7 +107,7 @@ const IndexPage = ({ data }) => {
         {/* Grande card featured — dernier épisode */}
         {allEpisodes[0] && (
           <FeaturedCard
-            href={`/podcasts/${allEpisodes[0].guid}`}
+            href={`/podcasts/${slugify(allEpisodes[0].title)}/`}
             imageUrl={allEpisodes[0].itunes.image}
             imageAlt={allEpisodes[0].title}
             label={`Saison ${allEpisodes[0].itunes.season} · Épisode ${allEpisodes[0].itunes.episode}`}
@@ -119,7 +120,7 @@ const IndexPage = ({ data }) => {
             }
             cta={
               <Link
-                to={`/podcasts/${allEpisodes[0].guid}`}
+                to={`/podcasts/${slugify(allEpisodes[0].title)}/`}
                 aria-label={`Écouter l'épisode : ${allEpisodes[0].title}`}
                 className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors hover:text-neutral-900"
               >
@@ -135,7 +136,7 @@ const IndexPage = ({ data }) => {
             {allEpisodes.slice(1).map((episode: any) => (
               <ContentCard
                 key={episode.guid}
-                href={`/podcasts/${episode.guid}`}
+                href={`/podcasts/${slugify(episode.title)}/`}
                 imageUrl={episode.itunes.image}
                 imageAlt={episode.title}
                 meta={`Saison ${episode.itunes.season} · Épisode ${episode.itunes.episode}`}
@@ -147,7 +148,7 @@ const IndexPage = ({ data }) => {
                 }
                 action={
                   <Link
-                    to={`/podcasts/${episode.guid}`}
+                    to={`/podcasts/${slugify(episode.title)}/`}
                     aria-label={`Écouter : ${episode.title}`}
                     className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors hover:text-neutral-900"
                   >

--- a/src/templates/episode.tsx
+++ b/src/templates/episode.tsx
@@ -22,7 +22,7 @@ export default function Episode({ pageContext }) {
     () => ({
       title,
       audio: { src: pageContext.enclosure.url, type: 'audio/mpeg' },
-      link: `/podcasts/${pageContext.guid}`,
+      link: `/podcasts/${pageContext.slug}`,
     }),
     [pageContext]
   );
@@ -30,7 +30,6 @@ export default function Episode({ pageContext }) {
 
   return (
     <Layout withLastPodcast={false}>
-
       {/* ── HERO IMAGE ───────────────────────────────────────────── */}
       <div className="-mx-4 relative h-[55vh] min-h-[340px] overflow-hidden">
         <img
@@ -54,7 +53,6 @@ export default function Episode({ pageContext }) {
 
       {/* ── CONTENU ──────────────────────────────────────────────── */}
       <div className="mx-auto max-w-3xl px-6 lg:px-0">
-
         {/* Bouton play — style "description" de l'article */}
         <div className="flex items-center gap-5 border-b border-neutral-200 py-8">
           <PlayButton player={player} size="medium" />
@@ -94,7 +92,10 @@ export default function Episode({ pageContext }) {
               Présenté par
             </p>
             <p className="text-sm font-light leading-relaxed text-neutral-500">
-              Aldjia Boughias — développeuse web orientée Art et Culture, exploratrice de l'Histoire de l'Art le reste du temps. J'ai créé ART AU FÉMININ pour donner aux femmes artistes la place qu'elles méritent dans notre mémoire collective.
+              Aldjia Boughias — développeuse web orientée Art et Culture,
+              exploratrice de l'Histoire de l'Art le reste du temps. J'ai créé
+              ART AU FÉMININ pour donner aux femmes artistes la place qu'elles
+              méritent dans notre mémoire collective.
             </p>
           </div>
         </section>
@@ -108,8 +109,9 @@ export default function Episode({ pageContext }) {
             Vous avez aimé cet épisode ?
           </h2>
           <p className="mb-5 text-sm font-light leading-relaxed text-neutral-500">
-            Si ce contenu vous a plu, vous pouvez soutenir ART AU FÉMININ sur Tipeee.
-            Chaque contribution aide à produire de nouveaux épisodes et articles.
+            Si ce contenu vous a plu, vous pouvez soutenir ART AU FÉMININ sur
+            Tipeee. Chaque contribution aide à produire de nouveaux épisodes et
+            articles.
           </p>
           <a
             href="https://fr.tipeee.com/art-au-feminin"
@@ -141,7 +143,11 @@ export default function Episode({ pageContext }) {
                 rel="noopener noreferrer"
                 className="group flex items-center gap-3 border border-neutral-200 p-4 transition-colors hover:border-neutral-400"
               >
-                <img src={platform.imageUrl} alt={platform.name} className="size-6 shrink-0" />
+                <img
+                  src={platform.imageUrl}
+                  alt={platform.name}
+                  className="size-6 shrink-0"
+                />
                 <span className="text-sm font-light text-neutral-700 transition-colors group-hover:text-neutral-900">
                   {platform.name}
                 </span>
@@ -149,7 +155,6 @@ export default function Episode({ pageContext }) {
             ))}
         </div>
       </div>
-
     </Layout>
   );
 }
@@ -198,7 +203,13 @@ export const Head = ({
       '@type': 'PodcastEpisode',
       name: title,
       description,
-      keywords: ['femmes artistes', 'podcast art', "histoire de l'art", 'art au féminin', 'artistes femmes'],
+      keywords: [
+        'femmes artistes',
+        'podcast art',
+        "histoire de l'art",
+        'art au féminin',
+        'artistes femmes',
+      ],
       url: canonicalUrl,
       ...(episodeImage && { image: episodeImage }),
       inLanguage: 'fr',

--- a/src/templates/podcasts-list.tsx
+++ b/src/templates/podcasts-list.tsx
@@ -1,6 +1,8 @@
 import { graphql, Link } from 'gatsby';
 import React, { useMemo } from 'react';
 
+import { slugify } from '../utils/slugify';
+
 import { ContentCard } from '../components/content-card';
 import { FeaturedCard } from '../components/featured-card';
 import Layout from '../components/layout';
@@ -15,9 +17,9 @@ function EpisodeCard({ episode }: { episode: any }) {
     () => ({
       title: episode.title,
       audio: { src: episode.enclosure.url, type: 'audio/mpeg' },
-      link: `/podcasts/${episode.guid}`,
+      link: `/podcasts/${slugify(episode.title)}/`,
     }),
-    [episode],
+    [episode]
   );
   const player = useAudioPlayer(audioPlayerData);
 
@@ -35,7 +37,7 @@ function EpisodeCard({ episode }: { episode: any }) {
 
   return (
     <ContentCard
-      href={`/podcasts/${episode.guid}`}
+      href={`/podcasts/${slugify(episode.title)}/`}
       imageUrl={episode.itunes.image}
       imageAlt={episode.title}
       meta={meta}
@@ -77,7 +79,6 @@ const PodcastsListTemplate = ({ data, pageContext }: PodcastsListProps) => {
 
   return (
     <Layout>
-
       {/* ── EN-TÊTE ───────────────────────────────────────────────── */}
       <section className="mx-auto mb-10 mt-8 w-11/12 max-w-7xl border-b border-neutral-200 pb-8">
         <p className="mb-2 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400">
@@ -97,7 +98,7 @@ const PodcastsListTemplate = ({ data, pageContext }: PodcastsListProps) => {
             </h2>
           </div>
           <FeaturedCard
-            href={`/podcasts/${featured.guid}`}
+            href={`/podcasts/${slugify(featured.title)}/`}
             imageUrl={featured.itunes.image}
             imageAlt={featured.title}
             label={`Saison ${featured.itunes.season} · Épisode ${featured.itunes.episode}`}
@@ -109,7 +110,7 @@ const PodcastsListTemplate = ({ data, pageContext }: PodcastsListProps) => {
             }
             cta={
               <Link
-                to={`/podcasts/${featured.guid}`}
+                to={`/podcasts/${slugify(featured.title)}/`}
                 aria-label={`Écouter l'épisode : ${featured.title}`}
                 className="text-xs font-semibold uppercase tracking-[0.25em] text-neutral-400 transition-colors hover:text-neutral-900"
               >
@@ -136,19 +137,18 @@ const PodcastsListTemplate = ({ data, pageContext }: PodcastsListProps) => {
         </section>
       )}
 
-      <Pagination currentPage={currentPage} numPages={numPages} basePath="/podcasts" />
-
+      <Pagination
+        currentPage={currentPage}
+        numPages={numPages}
+        basePath="/podcasts"
+      />
     </Layout>
   );
 };
 
 export const query = graphql`
   query PodcastsListQuery($skip: Int!, $limit: Int!) {
-    allAnchorEpisode(
-      sort: { isoDate: DESC }
-      limit: $limit
-      skip: $skip
-    ) {
+    allAnchorEpisode(sort: { isoDate: DESC }, limit: $limit, skip: $skip) {
       nodes {
         id
         guid

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -1,0 +1,11 @@
+export const slugify = (text: string): string =>
+  text
+    .toString()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);


### PR DESCRIPTION
## Résumé

Migration des URLs d'épisodes podcast de UUIDs vers des slugs lisibles générés depuis le titre. Redirects 301 automatiques depuis les anciennes URLs pour préserver le référencement existant.

**Exemple :**
- AVANT : `/podcasts/6ed935b1-1baa-4a00-8b3e-6045ea13a014/`
- APRÈS  : `/podcasts/marguerite-peltzer-marianne-le-morvan/`

## Modifications

- **`src/utils/slugify.ts`** — utilitaire partagé (normalisation NFD, suppression accents/caractères spéciaux, kebab-case, limite 80 chars)
- **`gatsby-node.js`** — génération des pages avec slug + redirects 301 UUID→slug et `/podcast/`→`/podcasts/`
- **`gatsby-config.js`** — ajout de `gatsby-plugin-netlify` pour que les redirects soient écrits dans `_redirects` (vrais 301 HTTP)
- **`src/templates/`** et **`src/components/`** — tous les liens internes mis à jour (8 fichiers)
- **Correction bug** : `layout.tsx` utilisait `/${guid}` au lieu de `/podcasts/:slug`

## À vérifier avant de merger

- [ ] Les redirects 301 sont bien présents dans `public/_redirects` après build
- [ ] Les nouvelles URLs s'affichent correctement (`/podcasts/[slug]/`)
- [ ] Les anciennes URLs UUID redirigent bien vers les nouvelles
- [ ] Les polices et le player audio fonctionnent sur les pages épisodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)