### PR TITLE
fix(index): sort podcast episodes by date DESC on landing page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -313,7 +313,7 @@ export const indexPageQuery = graphql`
         description
       }
     }
-    allAnchorEpisode(limit: 4) {
+    allAnchorEpisode(sort: { isoDate: DESC }, limit: 4) {
       nodes {
         ...AnchorEpisodeFragment
       }


### PR DESCRIPTION
La query GraphQL sur la landing page n'avait pas de tri, contrairement à la page podcasts. Résultat : le dernier épisode n'apparaissait pas forcément en premier.

Fix: ajout de `sort: { isoDate: DESC }` sur `allAnchorEpisode`.